### PR TITLE
Migrate from gs://cpg-reference to gs://cpg-common-main/references

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Source(
 Is expanded into flat
 
 ```toml
-liftover_38_to_37 = "gs://cpg-reference/liftover/grch38_to_grch37.over.chain.gz"
+liftover_38_to_37 = "gs://cpg-common-main/references/liftover/grch38_to_grch37.over.chain.gz"
 ```
 
 Whereas
@@ -36,6 +36,6 @@ Is expanded into a section
 
 ```toml
 [gatk_sv]
-wham_include_list_bed_file = "gs://cpg-reference/hg38/v0/sv-resources/resources/v1/wham_whitelist.bed"
-primary_contigs_list = "gs://cpg-reference/hg38/v0/sv-resources/resources/v1/primary_contigs.list"
+wham_include_list_bed_file = "gs://cpg-common-main/references/hg38/v0/sv-resources/resources/v1/wham_whitelist.bed"
+primary_contigs_list = "gs://cpg-common-main/references/hg38/v0/sv-resources/resources/v1/primary_contigs.list"
 ```

--- a/references.py
+++ b/references.py
@@ -60,7 +60,7 @@ SOURCES = [
         # No `src` field: the process of building it is described in `vep/README.md`.
         # Hopefully to be deprecated once VEP for Hail Query is finalised:
         # https://github.com/hail-is/hail/pull/12428)
-        src='gs://cpg-reference/vep/105.0/mount',
+        src='gs://cpg-common-main/references/vep/105.0/mount',
         dst='vep/105.0/mount',
     ),
     Source(
@@ -80,7 +80,7 @@ SOURCES = [
     Source(
         'broad',
         # src='gs://gcp-public-data--broad-references/hg38/v0',
-        src='gs://cpg-reference/hg38/v0',
+        src='gs://cpg-common-main/references/hg38/v0',
         dst='hg38/v0',
         transfer_cmd=gcs_rsync,
         files=dict(
@@ -122,7 +122,7 @@ SOURCES = [
     Source(
         'gatk_sv',
         # src='gs://gatk-sv-resources-public/hg38/v0/sv-resources',
-        src='gs://cpg-reference/hg38/v0/sv-resources',
+        src='gs://cpg-common-main/references/hg38/v0/sv-resources',
         dst='gatk-sv/hg38/v0/sv-resources',
         transfer_cmd=gcs_rsync,
         files=dict(
@@ -164,7 +164,7 @@ SOURCES = [
     ),
     Source(
         'gnomad',
-        src='gs://cpg-reference/gnomad/v0',
+        src='gs://cpg-common-main/references/gnomad/v0',
         # src='gs://gcp-public-data--gnomad/resources/grch38',
         dst='gnomad/v0',
         transfer_cmd=gcs_cp_r,

--- a/vep/README.md
+++ b/vep/README.md
@@ -49,7 +49,7 @@ The Query's `hl.vep` function works only with the Spark backend on a Dataproc cl
 Script is parametrised with `__VEP_VERSION__`, so pass it through `sed` when copying to the bucket:
 
 ```shell
-cat dataproc-init.sh | sed "s/__VEP_VERSION__/${VEP_VERSION}/g" | gsutil cp - gs://cpg-reference/vep/${VEP_VERSION}/dataproc/init.sh
+cat dataproc-init.sh | sed "s/__VEP_VERSION__/${VEP_VERSION}/g" | gsutil cp - gs://cpg-common-main/references/vep/${VEP_VERSION}/dataproc/init.sh
 ```
 
 2. Similarly, the JSON config script for dataproc [dataproc-config.json](dataproc-config.json) is also copied from the [Hail codebase](https://github.com/hail-is/hail/blob/cc0a051740f4de08408e6a2094ffcb1c3158ee9c/hail/python/hailtop/hailctl/hdinsight/resources/vep-GRCh38.json) and modified to reflect the newer VEP versions, and additionally has `mane_select:String,mane_plus_clinical:String` in schema to load MANE IDs that are supported by modern versions of VEP.
@@ -57,7 +57,7 @@ cat dataproc-init.sh | sed "s/__VEP_VERSION__/${VEP_VERSION}/g" | gsutil cp - gs
 The config is parametrised with `__VEP_VERSION__`, so pass it through `sed` when copying to the bucket:
 
 ```sh
-cat dataproc-config.json | sed "s/__VEP_VERSION__/${VEP_VERSION}/g" | gsutil cp - gs://cpg-reference/vep/${VEP_VERSION}/dataproc/config.json
+cat dataproc-config.json | sed "s/__VEP_VERSION__/${VEP_VERSION}/g" | gsutil cp - gs://cpg-common-main/references/vep/${VEP_VERSION}/dataproc/config.json
 ```
 
 We also have a separate version of the config `dataproc-config-no-exac.json` for older VEP versions (before v88). In this version, ExAC fields are excluded: they used to contain non-numerical format for ExAC frequencies, e.g. `"exac_adj_maf":"-:0.2934,-:8.292e-06", "exac_maf":"-:0.293,-:8.261e-06"`, which would break parsing into Hail using the schema where those fields are specified as floats. 

--- a/vep/copy-references.py
+++ b/vep/copy-references.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 
 """
-Use Hail Batch to transfer VEP cache bundle into the cpg-reference bucket,
+Use Hail Batch to transfer VEP cache bundle into the cpg-common-main bucket,
 and prepare a GCP mount for cloudfuse.
 """
 

--- a/vep/dataproc-init.sh
+++ b/vep/dataproc-init.sh
@@ -4,7 +4,7 @@
 ## Modified copy of https://github.com/hail-is/hail/blob/main/hail/python/hailtop/hailctl/dataproc/resources/vep-GRCh38.sh:
 # * allow using a more recent VEP (e.g. 105), parametrised with $VEP_VERSION
 # * using the CPG artifact registry VEP image, based on biocontainers image
-# * changed the bucket to gs://cpg-reference/vep
+# * changed the bucket to gs://cpg-common-main/references/vep
 ##############
 
 set -ex
@@ -16,9 +16,9 @@ if [[ -z "$VEP_VERSION" ]]; then
 fi
 
 export IMAGE=australia-southeast1-docker.pkg.dev/cpg-common/images/vep:${VEP_VERSION}
-export CONFIG_PATH=gs://cpg-reference/vep/${VEP_VERSION}/dataproc/config.json
-export CACHE_PATH=gs://cpg-reference/vep/${VEP_VERSION}/cache.tar
-export LOFTEE_PATH=gs://cpg-reference/vep/loftee.tar
+export CONFIG_PATH=gs://cpg-common-main/references/vep/${VEP_VERSION}/dataproc/config.json
+export CACHE_PATH=gs://cpg-common-main/references/vep/${VEP_VERSION}/cache.tar
+export LOFTEE_PATH=gs://cpg-common-main/references/vep/loftee.tar
 
 mkdir -p /vep_data/loftee/
 

--- a/vep/test/test-batch-backend.py
+++ b/vep/test/test-batch-backend.py
@@ -13,14 +13,14 @@ def main(vep_version: str):
     """
     Run VEP in parallel using Picard tools intervals as partitions.
     """
-    vcf_path = f'gs://cpg-reference-test/vep/test/sample.vcf.gz'
-    out_ht_path = f'gs://cpg-reference-test/vep/test/batch/sample-vep.ht'
+    vcf_path = f'gs://cpg-common-main/references-test/vep/test/sample.vcf.gz'
+    out_ht_path = f'gs://cpg-common-main/references-test/vep/test/batch/sample-vep.ht'
 
     b = get_batch(f'Test VEP with Batch Backend, VEP v{vep_version}')
     add_vep_jobs(
         b=b,
         vcf_path=to_path(vcf_path),
-        tmp_prefix=to_path('gs://cpg-reference-test-tmp/vep/test'),
+        tmp_prefix=to_path('gs://cpg-common-main/references-test-tmp/vep/test'),
         out_path=to_path(out_ht_path),
         scatter_count=2,
     )

--- a/vep/test/test-dataproc-wrapper.py
+++ b/vep/test/test-dataproc-wrapper.py
@@ -13,9 +13,9 @@ def main(vep_version: str):
     """
     from analysis_runner import dataproc
 
-    mt_path = f'gs://cpg-reference-test/vep/test/sample.vcf.mt'
+    mt_path = f'gs://cpg-common-main/references-test/vep/test/sample.vcf.mt'
     out_mt_path = (
-        f'gs://cpg-reference-test/vep/test/dataproc/sample-vep.vcf.mt'
+        f'gs://cpg-common-main/references-test/vep/test/dataproc/sample-vep.vcf.mt'
     )
 
     b = get_batch(f'Test VEP with Spark backend, VEP v{vep_version}')
@@ -24,7 +24,7 @@ def main(vep_version: str):
         f'test-dataproc-script.py {mt_path} {out_mt_path}',
         max_age='4h',
         job_name=f'Test VEP {vep_version}',
-        init=[f'gs://cpg-reference/vep/{vep_version}/dataproc/init.sh'],
+        init=[f'gs://cpg-common-main/references/vep/{vep_version}/dataproc/init.sh'],
         worker_machine_type='n1-highmem-8',
         worker_boot_disk_size=200,
         secondary_worker_boot_disk_size=200,


### PR DESCRIPTION
@vladsavelyev @MattWellie Currently there's only 105.0 in `cpg-common-main`:

```bash
❯ gsutil ls gs://cpg-common-main/references/vep
gs://cpg-common-main/references/vep/105.0/
```

Should I manually copy over (or regenerate) the other versions or not?

```bash
❯ gsutil ls gs://cpg-reference/vep/
gs://cpg-reference/vep/homo_sapiens_vep_105_GRCh38.tar.gz
gs://cpg-reference/vep/loftee-beta.tar
gs://cpg-reference/vep/loftee.tar
gs://cpg-reference/vep/vep-GRCh38-perl5_set.sh
gs://cpg-reference/vep/104.3/
gs://cpg-reference/vep/105.0/
gs://cpg-reference/vep/88.10/
gs://cpg-reference/vep/service/
```