### PR TITLE
Revert reference sources, add more docs

### DIFF
--- a/references.py
+++ b/references.py
@@ -60,7 +60,6 @@ SOURCES = [
         # No `src` field: the process of building it is described in `vep/README.md`.
         # Hopefully to be deprecated once VEP for Hail Query is finalised:
         # https://github.com/hail-is/hail/pull/12428)
-        src='gs://cpg-common-main/references/vep/105.0/mount',
         dst='vep/105.0/mount',
     ),
     Source(
@@ -79,8 +78,8 @@ SOURCES = [
     ),
     Source(
         'broad',
-        # src='gs://gcp-public-data--broad-references/hg38/v0',
-        src='gs://cpg-common-main/references/hg38/v0',
+        # The Broad hg38 reference bundle
+        src='gs://gcp-public-data--broad-references/hg38/v0',
         dst='hg38/v0',
         transfer_cmd=gcs_rsync,
         files=dict(
@@ -121,8 +120,8 @@ SOURCES = [
     ),
     Source(
         'gatk_sv',
-        # src='gs://gatk-sv-resources-public/hg38/v0/sv-resources',
-        src='gs://cpg-common-main/references/hg38/v0/sv-resources',
+        # The Broad resources for running the GATK-SV workflow
+        src='gs://gatk-sv-resources-public/hg38/v0/sv-resources',
         dst='gatk-sv/hg38/v0/sv-resources',
         transfer_cmd=gcs_rsync,
         files=dict(
@@ -164,8 +163,8 @@ SOURCES = [
     ),
     Source(
         'gnomad',
-        src='gs://cpg-common-main/references/gnomad/v0',
-        # src='gs://gcp-public-data--gnomad/resources/grch38',
+        # The Broad resources for running the GnomAD QC pipeline
+        src='gs://gcp-public-data--gnomad/resources/grch38',
         dst='gnomad/v0',
         transfer_cmd=gcs_cp_r,
         files=dict(
@@ -182,18 +181,21 @@ SOURCES = [
     ),
     Source(
         'seqr_combined_reference_data',
+        # The Broad resources for annotation for the Seqr Loader
         src='gs://seqr-reference-data/GRCh38/all_reference_data/combined_reference_data_grch38.ht',
         dst='seqr/v0/combined_reference_data_grch38.ht',
         transfer_cmd=gcs_cp_r,
     ),
     Source(
         'seqr_clinvar',
+        # The Broad resources for annotation for the Seqr Loader
         src='gs://seqr-reference-data/GRCh38/clinvar/clinvar.GRCh38.ht',
         dst='seqr/v0/clinvar.GRCh38.ht',
         transfer_cmd=gcs_cp_r,
     ),
     Source(
         'syndip',
+        # The Broad resources for running variant calling validation on common benchmark datasets
         src='gs://gcp-public-data--gnomad/resources/grch38/syndip',
         dst='validation/syndip',
         transfer_cmd=gcs_rsync,
@@ -206,6 +208,7 @@ SOURCES = [
     ),
     Source(
         'na12878',
+        # The Broad resources for running variant calling validation on common benchmark datasets
         src='gs://gcp-public-data--gnomad/resources/grch38/na12878',
         dst='validation/na12878',
         transfer_cmd=gcs_rsync,


### PR DESCRIPTION
We had `src` temporarily set to AU buckets so we don't transfer again from the US. Should be safe to remove now that it's all transferred, and `rsync` should make sure the automation won't copy everything from the US again.