### PR TITLE
Correction to VEP cache process

### DIFF
--- a/vep/README.md
+++ b/vep/README.md
@@ -111,5 +111,5 @@ analysis-runner \
     --access-level full \
     --description "VEP: Sync 110 to production" \
     --output-dir vep_110 \
-    bash scripts/prod_sync_script.sh 110
+    bash vep/prod_sync_script.sh 110
 ```

--- a/vep/prod_sync_script.sh
+++ b/vep/prod_sync_script.sh
@@ -20,5 +20,5 @@ if gcloud storage ls "gs://cpg-common-main/references/vep/${VERSION}/mount" > /d
     exit 1
 else
     echo "Target location vacant, copying"
-    gcloud storage rsync --recursive "gs://cpg-common-test/references/vep/${VERSION}/mount" "gs://cpg-common-main/references/vep/${VERSION}/mount"
+    gsutil rsync -r -m "gs://cpg-common-test/references/vep/${VERSION}/mount" "gs://cpg-common-main/references/vep/${VERSION}/mount"
 fi


### PR DESCRIPTION
Closes #34  (should have been linked to the previous PR)

Changes the example analysis-runner invocation to the correct path

Replaces `gcloud storage rsync --recursive` to `gsutil rsync -r -m` as the driver image has an older version of the google cloud sdk, meaning that `storage rsync` isn't available