### PR TITLE
Generate and push a STAR reference

### DIFF
--- a/star/README.md
+++ b/star/README.md
@@ -1,0 +1,49 @@
+# Building a new STAR reference
+
+## Context
+
+The following steps describe how to prepare a reference package for the [STAR aligner](https://github.com/alexdobin/STAR). This is required for running the rare disease RNA sequencing analysis pipeline.
+
+## STAR Image
+
+A Dockerfile for generating a STAR image exists in the populationgenomics `Images` repository (`images/star/Dockerfile`). At the time of writing (15-12-2023), the current version of STAR being containerised is 2.7.10b. To update the version of STAR within the CPG artifact registry, a pull request will need to be made in the `Images` repository to change the defaut value of the `VERSION` variable in the Dockerfile, as well as updating the file `images.toml` in the root directory of the `Images` repository to reflect the new version of STAR. Once the changes have been merged into main, the new STAR image will be automatically built and pushed to artifact registry.
+
+## Building the STAR reference
+
+1. Update the file `star.toml` by supplying the new version of STAR to the `version` parameter.
+2. (Optional) If a newer Gencode version is desired (currently version 44 at the time of writing), also update the `gencode_version` varialbe.
+2. From the root directory of the `references` repository, run `analysis-runner` to start the script on Hail Batch:
+
+```bash
+STAR_VERSION="2.7.10b"  # Update to your current version number
+analysis-runner \
+    --dataset common \
+    --description "Generate STAR reference" \
+    --output-dir "references/star/${STAR_VERSION}/hg38 \
+    --access-level standard \
+    --config star/star.toml \
+    --image australia-southeast1-docker.pkg.dev/cpg-common/images/cpg_workflows:latest \
+    python3 star/build_star_reference.py
+```
+
+This will generate the reference package at `gs://cpg-common-main-test/references/star/<STAR_VERSION>/hg38`. This can be used for testing prior to pushing to production. Due to it's location within the `cpg-common-main-test` bucket, it will be deleted after a week.
+
+## Production
+
+Once testing is complete, the new STAR reference can be moved into production. The companion script
+[prod_sync_script.sh](prod_sync_script.sh) can be used to move the data from the temporary test location into
+the main bucket. The script takes one argument - the STAR version to push. It
+does a minimal check that the source location `gs://cpg-common-main-test/references/star/${STAR_VERSION}/hg38`
+exists, and the target location `gs://cpg-common-main/references/star/${STAR_VERSION}/hg38` does not. It 
+then initiates the rsync between the two locations. This should be run using analysis-runner, at the
+`full` access level:
+
+```bash
+STAR_VERSION="2.7.10b"  # Update to your current version number
+analysis-runner \
+    --dataset common \
+    --access-level full \
+    --description "STAR: Sync ${STAR_VERSION} to production" \
+    --output-dir "references/star/${STAR_VERSION}/hg38" \
+    bash star/prod_sync_script.sh ${STAR_VERSION}
+```

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -18,10 +18,10 @@ STORAGE = config['workflow'].get('storage', '150Gi')
 SJDB_OVERHANG = int(config['workflow'].get('sjdb_overhang', 100))
 GENCODE_VERSION = str(config['workflow'].get('gencode_version', 44))
 GENCODE_BASE_URL = f'https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{GENCODE_VERSION}'
-GENCODE_FASTA_BASENAME = 'GRCh38.primary_assembly.genome.fa'
 GENCODE_GTF_BASENAME = f'gencode.v{GENCODE_VERSION}.primary_assembly.annotation.gtf'
-GENCODE_FASTA_URL = f'{GENCODE_BASE_URL}/{GENCODE_FASTA_BASENAME}.gz'
 GENCODE_GTF_URL = f'{GENCODE_BASE_URL}/{GENCODE_GTF_BASENAME}.gz'
+# GENCODE_FASTA_BASENAME = 'GRCh38.primary_assembly.genome.fa'
+# GENCODE_FASTA_URL = f'{GENCODE_BASE_URL}/{GENCODE_FASTA_BASENAME}.gz'
 
 sb = hb.ServiceBackend(billing_project=BILLING_PROJECT, remote_tmpdir=remote_tmpdir())
 b = hb.Batch(backend=sb, default_image=DEFAULT_IMAGE)
@@ -65,15 +65,15 @@ j.declare_resource_group(star_ref=star_ref_files)
 cmd = f"""\
     mkdir -p {TMP_DL_DIR}
     cd {TMP_DL_DIR}
-    wget {GENCODE_FASTA_URL}
     wget {GENCODE_GTF_URL}
+    gunzip {GENCODE_GTF_BASENAME}.gz
     mkdir -p {TMP_MKREF_DIR}
     cd {TMPDIR}
     STAR
         --runThreadN {str(CPU)}
         --runMode genomeGenerate
         --genomeDir hg38
-        --genomeFastaFiles {TMP_DL_DIR / GENCODE_FASTA_BASENAME}
+        --genomeFastaFiles {reference_path('broad/fasta')}
         --sjdbGTFfile {TMP_DL_DIR / GENCODE_GTF_BASENAME}
         --sjdbOverhang {str(SJDB_OVERHANG)}
     """

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -11,10 +11,8 @@ from textwrap import dedent
 config = get_config()
 BILLING_PROJECT = config['hail']['billing_project']
 DEFAULT_IMAGE = config['workflow']['driver_image']
-TMP_BUCKET = config['storage']['common']['tmp']
-TEST_TMP_BUCKET = config['storage']['common']['test']['tmp']
 IS_TEST = config['workflow']['access_level'] == 'test'
-TEST_BUCKET = TMP_BUCKET if IS_TEST else TEST_TMP_BUCKET
+TEST_BUCKET = config['storage']['common']['tmp'] if IS_TEST else config['storage']['common']['test']['tmp']
 CPU = int(config['workflow'].get('n_cpu', 8))
 MEMORY = config['workflow'].get('memory', 'standard')
 STORAGE = config['workflow'].get('storage', '150Gi')

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -67,8 +67,10 @@ cmd = f"""\
     # Strip FASTA down to just the major chromosomes
     cd {TMP_FASTA_DIR}
     samtools faidx {ref_fasta.fa}
-    samtools faidx {ref_fasta.fa} {major_chromosomes} > {get_ref_j.ref_files.fa}
-    samtools faidx hg38.fa && mv hg38.fa.fai {get_ref_j.ref_files.fa_idx}
+    samtools faidx {ref_fasta.fa} {major_chromosomes} > hg38.fa
+    samtools faidx hg38.fa
+    mv hg38.fa {get_ref_j.ref_files.fa}
+    mv hg38.fa.fai {get_ref_j.ref_files.fa_idx}
     """
 cmd = dedent(cmd)
 

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -114,12 +114,12 @@ cmd = f"""\
 
     # Build reference
     cd {TMP_MKREF_DIR}
-    STAR
-        --runThreadN {str(CPU)}
-        --runMode genomeGenerate
-        --genomeDir {TMP_GENOME_DIR}
-        --genomeFastaFiles {get_ref_j.ref_files.fa}
-        --sjdbGTFfile {get_ref_j.ref_files.gtf}
+    STAR \
+        --runThreadN {str(CPU)} \
+        --runMode genomeGenerate \
+        --genomeDir {TMP_GENOME_DIR} \
+        --genomeFastaFiles {get_ref_j.ref_files.fa} \
+        --sjdbGTFfile {get_ref_j.ref_files.gtf} \
         --sjdbOverhang {str(SJDB_OVERHANG)}
     """
 cmd = dedent(cmd)

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -59,7 +59,7 @@ star_ref_file_basenames = {
     'transcript_info': 'transcriptInfo.tab',
 }
 star_ref_files = {
-    key: f'{TMP_GENOME_DIR}/file'
+    key: f'{TMP_GENOME_DIR}/{file}'
     for key, file in star_ref_file_basenames.items()
 }
 j.declare_resource_group(star_ref=star_ref_files)

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -81,7 +81,7 @@ cmd = f"""\
 
     # Strip FASTA down to just the major chromosomes
     cd {TMP_FASTA_DIR}
-    samtools faidx {reference_path('broad/fasta')} {major_chromosomes} > hg38.fa
+    samtools faidx {reference_path('broad/ref_fasta')} {major_chromosomes} > hg38.fa
     samtools faidx hg38.fa
 
     # Build reference

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -101,6 +101,6 @@ j.command(cmd)
 # Write outputs
 # Have to do this one-by-one since the output files don't have a simple naming convention
 for key in star_ref_files:
-    b.write_output(j[key], str(OUT_GENOME_DIR / star_ref_file_basenames[key]))
+    b.write_output(j.star_ref[key], str(OUT_GENOME_DIR / star_ref_file_basenames[key]))
 
 b.run(wait=False)

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -14,7 +14,7 @@ DEFAULT_IMAGE = config['workflow']['driver_image']
 IS_TEST = config['workflow']['access_level'] == 'test'
 TEST_BUCKET = config['storage']['common']['tmp'] if IS_TEST else config['storage']['common']['test']['tmp']
 CPU = int(config['workflow'].get('n_cpu', 8))
-MEMORY = config['workflow'].get('memory', 'standard')
+MEMORY = config['workflow'].get('memory', 'highmem')
 STORAGE = config['workflow'].get('storage', '150Gi')
 STAR_VERSION = str(config['star']['version'])
 SJDB_OVERHANG = int(config['star'].get('sjdb_overhang', 100))

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -85,7 +85,7 @@ j.storage(STORAGE)
 
 TMP_MKREF_DIR = f'{TMPDIR}/mkref'
 TMP_GENOME_DIR = f'{TMP_MKREF_DIR}/hg38'
-OUT_GENOME_DIR = to_path(TEST_BUCKET) / 'references' / 'star' / 'hg38'
+OUT_GENOME_DIR = to_path(TEST_BUCKET) / 'references' / 'star' / str(STAR_VERSION) / 'hg38'
 
 star_ref_files = {
     'chr_len': 'chrLength.txt',

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -49,6 +49,10 @@ get_ref_j.declare_resource_group(
     },
 )
 
+ref_fasta = b.read_input_group(
+    fa=reference_path('broad/ref_fasta'),
+)
+
 cmd = f"""\
     # Create directories
     mkdir -p {TMP_DL_DIR}
@@ -62,7 +66,8 @@ cmd = f"""\
 
     # Strip FASTA down to just the major chromosomes
     cd {TMP_FASTA_DIR}
-    samtools faidx {reference_path('broad/ref_fasta')} {major_chromosomes} > {get_ref_j.ref_files.fa}
+    samtools faidx {ref_fasta.fa}
+    samtools faidx {ref_fasta.fa} {major_chromosomes} > {get_ref_j.ref_files.fa}
     samtools faidx hg38.fa && mv hg38.fa.fai {get_ref_j.ref_files.fa_idx}
     """
 cmd = dedent(cmd)

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -11,8 +11,8 @@ from textwrap import dedent
 config = get_config()
 BILLING_PROJECT = config['hail']['billing_project']
 DEFAULT_IMAGE = config['workflow']['driver_image']
-IS_TEST = config['workflow']['access_level'] == 'test'
-TEST_BUCKET = config['storage']['common']['tmp'] if IS_TEST else config['storage']['common']['test']['tmp']
+# IS_TEST = config['workflow']['access_level'] == 'test'
+TEST_BUCKET = config['storage']['common']['tmp']
 CPU = int(config['workflow'].get('n_cpu', 8))
 MEMORY = config['workflow'].get('memory', 'highmem')
 STORAGE = config['workflow'].get('storage', '150Gi')

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -59,7 +59,7 @@ star_ref_file_basenames = {
     'transcript_info': 'transcriptInfo.tab',
 }
 star_ref_files = {
-    key: TMP_GENOME_DIR / file
+    key: f'{TMP_GENOME_DIR}/file'
     for key, file in star_ref_file_basenames.items()
 }
 j.declare_resource_group(star_ref=star_ref_files)
@@ -90,8 +90,8 @@ cmd = f"""\
         --runThreadN {str(CPU)}
         --runMode genomeGenerate
         --genomeDir hg38
-        --genomeFastaFiles {TMP_FASTA_DIR / 'hg38.fa'}
-        --sjdbGTFfile {TMP_DL_DIR / 'hg38.gtf'}
+        --genomeFastaFiles {TMP_FASTA_DIR}/hg38.fa
+        --sjdbGTFfile {TMP_DL_DIR}/hg38.gtf
         --sjdbOverhang {str(SJDB_OVERHANG)}
     """
 cmd = dedent(cmd)

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -12,7 +12,9 @@ config = get_config()
 BILLING_PROJECT = config['hail']['billing_project']
 DEFAULT_IMAGE = config['workflow']['driver_image']
 TMP_BUCKET = config['storage']['common']['tmp']
-TEST_BUCKET = config['storage']['common']['test']
+TEST_TMP_BUCKET = config['storage']['common']['test']['tmp']
+IS_TEST = config['workflow']['access_level'] == 'test'
+TEST_BUCKET = TMP_BUCKET if IS_TEST else TEST_TMP_BUCKET
 CPU = int(config['workflow'].get('n_cpu', 8))
 MEMORY = config['workflow'].get('memory', 'standard')
 STORAGE = config['workflow'].get('storage', '150Gi')

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -1,16 +1,13 @@
 """
 Builds a STAR reference genome index through Hail batch.
 """
-import hailtop.batch as hb
 from cpg_utils import Path, to_path
 from cpg_utils.config import get_config
-from cpg_utils.hail_batch import remote_tmpdir, image_path, reference_path
+from cpg_utils.hail_batch import image_path, reference_path, get_batch
 from textwrap import dedent
 
 # Get config and parameters
 config = get_config()
-BILLING_PROJECT = config['hail']['billing_project']
-DEFAULT_IMAGE = config['workflow']['driver_image']
 # IS_TEST = config['workflow']['access_level'] == 'test'
 TEST_BUCKET = config['storage']['common']['tmp']
 CPU = int(config['workflow'].get('n_cpu', 8))
@@ -25,8 +22,7 @@ GENCODE_GTF_URL = f'{GENCODE_BASE_URL}/{GENCODE_GTF_BASENAME}.gz'
 # GENCODE_FASTA_BASENAME = 'GRCh38.primary_assembly.genome.fa'
 # GENCODE_FASTA_URL = f'{GENCODE_BASE_URL}/{GENCODE_FASTA_BASENAME}.gz'
 
-sb = hb.ServiceBackend(billing_project=BILLING_PROJECT, remote_tmpdir=remote_tmpdir())
-b = hb.Batch(backend=sb, default_image=DEFAULT_IMAGE)
+b = get_batch('Build Star Reference', default_image=config['workflow']['driver_image'])
 
 # Job to get and subset reference files
 get_ref_j = b.new_job('get-ref-files')

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -12,11 +12,13 @@ config = get_config()
 BILLING_PROJECT = config['hail']['billing_project']
 DEFAULT_IMAGE = config['workflow']['driver_image']
 TMP_BUCKET = config['storage']['common']['tmp']
+TEST_BUCKET = config['storage']['common']['test']
 CPU = int(config['workflow'].get('n_cpu', 8))
 MEMORY = config['workflow'].get('memory', 'standard')
 STORAGE = config['workflow'].get('storage', '150Gi')
-SJDB_OVERHANG = int(config['workflow'].get('sjdb_overhang', 100))
-GENCODE_VERSION = str(config['workflow'].get('gencode_version', 44))
+STAR_VERSION = str(config['star']['version'])
+SJDB_OVERHANG = int(config['star'].get('sjdb_overhang', 100))
+GENCODE_VERSION = str(config['star'].get('gencode_version', 44))
 GENCODE_BASE_URL = f'https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{GENCODE_VERSION}'
 GENCODE_GTF_BASENAME = f'gencode.v{GENCODE_VERSION}.primary_assembly.annotation.gtf'
 GENCODE_GTF_URL = f'{GENCODE_BASE_URL}/{GENCODE_GTF_BASENAME}.gz'
@@ -36,7 +38,7 @@ TMPDIR = Path("$BATCH_TMPDIR")
 TMP_DL_DIR = TMPDIR / 'dl'
 TMP_MKREF_DIR = TMPDIR / 'mkref'
 TMP_GENOME_DIR = TMP_MKREF_DIR / 'hg38'
-OUT_GENOME_DIR = Path(TMP_BUCKET) / 'star' / 'hg38'
+OUT_GENOME_DIR = Path(TEST_BUCKET) / 'references' / 'star' / 'hg38'
 
 star_ref_file_basenames = {
     'chr_len': 'chrLength.txt',

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -1,0 +1,89 @@
+"""
+Builds a STAR reference genome index through Hail batch.
+"""
+import hailtop.batch as hb
+from cpg_utils import Path
+from cpg_utils.config import get_config
+from cpg_utils.hail_batch import remote_tmpdir, image_path, reference_path
+from textwrap import dedent
+
+# Get config and parameters
+config = get_config()
+BILLING_PROJECT = config['hail']['billing_project']
+DEFAULT_IMAGE = config['workflow']['driver_image']
+TMP_BUCKET = config['storage']['common']['tmp']
+CPU = int(config['workflow'].get('n_cpu', 8))
+MEMORY = config['workflow'].get('memory', 'standard')
+STORAGE = config['workflow'].get('storage', '150Gi')
+SJDB_OVERHANG = int(config['workflow'].get('sjdb_overhang', 100))
+GENCODE_VERSION = str(config['workflow'].get('gencode_version', 44))
+GENCODE_BASE_URL = f'https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_{GENCODE_VERSION}'
+GENCODE_FASTA_BASENAME = 'GRCh38.primary_assembly.genome.fa'
+GENCODE_GTF_BASENAME = f'gencode.v{GENCODE_VERSION}.primary_assembly.annotation.gtf'
+GENCODE_FASTA_URL = f'{GENCODE_BASE_URL}/{GENCODE_FASTA_BASENAME}.gz'
+GENCODE_GTF_URL = f'{GENCODE_BASE_URL}/{GENCODE_GTF_BASENAME}.gz'
+
+sb = hb.ServiceBackend(billing_project=BILLING_PROJECT, remote_tmpdir=remote_tmpdir())
+b = hb.Batch(backend=sb, default_image=DEFAULT_IMAGE)
+
+j = b.new_job('build-star-reference')
+j.image(image_path('star'))
+j.cpu(CPU)
+j.memory(MEMORY)
+j.storage(STORAGE)
+
+TMPDIR = Path("$BATCH_TMPDIR")
+TMP_DL_DIR = TMPDIR / 'dl'
+TMP_MKREF_DIR = TMPDIR / 'mkref'
+TMP_GENOME_DIR = TMP_MKREF_DIR / 'hg38'
+OUT_GENOME_DIR = Path(TMP_BUCKET) / 'star' / 'hg38'
+
+star_ref_file_basenames = {
+    'chr_len': 'chrLength.txt',
+    'chr_name_len': 'chrNameLength.txt',
+    'chr_name': 'chrName.txt',
+    'chr_start': 'chrStart.txt',
+    'exon_ge_tr_info': 'exonGeTrInfo.tab',
+    'exon_info': 'exonInfo.tab',
+    'gene_info': 'geneInfo.tab',
+    'genome': 'Genome',
+    'genome_params': 'genomeParameters.txt',
+    'sa': 'SA',
+    'sa_idx': 'SAindex',
+    'sjdb_info': 'sjdbInfo.txt',
+    'sjdb_list_gtf': 'sjdbList.fromGTF.out.tab',
+    'sjdb_list': 'sjdbList.out.tab',
+    'transcript_info': 'transcriptInfo.tab',
+}
+star_ref_files = {
+    key: TMP_MKREF_DIR / file
+    for key, file in star_ref_file_basenames.items()
+}
+j.declare_resource_group(star_ref=star_ref_files)
+
+# Build command
+cmd = f"""\
+    mkdir -p {TMP_DL_DIR}
+    cd {TMP_DL_DIR}
+    wget {GENCODE_FASTA_URL}
+    wget {GENCODE_GTF_URL}
+    mkdir -p {TMP_MKREF_DIR}
+    cd {TMPDIR}
+    STAR
+        --runThreadN {str(CPU)}
+        --runMode genomeGenerate
+        --genomeDir hg38
+        --genomeFastaFiles {TMP_DL_DIR / GENCODE_FASTA_BASENAME}
+        --sjdbGTFfile {TMP_DL_DIR / GENCODE_GTF_BASENAME}
+        --sjdbOverhang {str(SJDB_OVERHANG)}
+    """
+cmd = dedent(cmd)
+
+j.command(cmd)
+
+# Write outputs
+# Have to do this one-by-one since the output files don't have a simple naming convention
+for key, file in star_ref_files.items():
+    j.write_output(file, str(OUT_GENOME_DIR / star_ref_file_basenames[key]))
+
+b.run(wait=False)

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -2,7 +2,7 @@
 Builds a STAR reference genome index through Hail batch.
 """
 import hailtop.batch as hb
-from cpg_utils import Path
+from cpg_utils import Path, to_path
 from cpg_utils.config import get_config
 from cpg_utils.hail_batch import remote_tmpdir, image_path, reference_path
 from textwrap import dedent
@@ -39,7 +39,7 @@ TMP_DL_DIR = f'{TMPDIR}/dl'
 TMP_FASTA_DIR = f'{TMPDIR}/fasta'
 TMP_MKREF_DIR = f'{TMPDIR}/mkref'
 TMP_GENOME_DIR = f'{TMP_MKREF_DIR}/hg38'
-OUT_GENOME_DIR = Path(TEST_BUCKET) / 'references' / 'star' / 'hg38'
+OUT_GENOME_DIR = to_path(TEST_BUCKET) / 'references' / 'star' / 'hg38'
 
 star_ref_file_basenames = {
     'chr_len': 'chrLength.txt',

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -37,6 +37,8 @@ j.storage(STORAGE)
 TMPDIR = '$BATCH_TMPDIR'
 TMP_DL_DIR = f'{TMPDIR}/dl'
 TMP_FASTA_DIR = f'{TMPDIR}/fasta'
+TMP_MKREF_DIR = f'{TMPDIR}/mkref'
+TMP_GENOME_DIR = f'{TMP_MKREF_DIR}/hg38'
 OUT_GENOME_DIR = to_path(TEST_BUCKET) / 'references' / 'star' / 'hg38'
 
 star_ref_files = {
@@ -65,7 +67,7 @@ cmd = f"""\
     # Create directories
     mkdir -p {TMP_DL_DIR}
     mkdir -p {TMP_FASTA_DIR}
-    mkdir -p {j.star_ref}
+    mkdir -p {TMP_GENOME_DIR}
 
     # Download GTF and strip down to just the major chromosomes
     cd {TMP_DL_DIR}
@@ -83,14 +85,16 @@ cmd = f"""\
     STAR
         --runThreadN {str(CPU)}
         --runMode genomeGenerate
-        --genomeDir {j.star_ref}
+        --genomeDir {TMP_GENOME_DIR}
         --genomeFastaFiles {TMP_FASTA_DIR}/hg38.fa
         --sjdbGTFfile {TMP_DL_DIR}/hg38.gtf
         --sjdbOverhang {str(SJDB_OVERHANG)}
-
-    # ls ea
     """
 cmd = dedent(cmd)
+
+# Move reference files to resource group
+for key, file in star_ref_files.items():
+    cmd += f'mv {TMP_GENOME_DIR}/{file} {j.star_ref[key]}\n'
 
 j.command(cmd)
 

--- a/star/build_star_reference.py
+++ b/star/build_star_reference.py
@@ -50,7 +50,7 @@ get_ref_j.declare_resource_group(
 )
 
 ref_fasta = b.read_input_group(
-    fa=reference_path('broad/ref_fasta'),
+    fa=str(reference_path('broad/ref_fasta')),
 )
 
 cmd = f"""\

--- a/star/prod_sync_script.sh
+++ b/star/prod_sync_script.sh
@@ -5,8 +5,8 @@
 STAR_VERSION=$1
 
 # check that the source location exists
-echo "Checking gs://cpg-common-test/references/star/hg38/${STAR_VERSION}"
-if gcloud storage ls "gs://cpg-common-test/references/star/hg38/${STAR_VERSION}" > /dev/null; then
+echo "Checking gs://cpg-common-test/references/star/${STAR_VERSION}/hg38"
+if gcloud storage ls "gs://cpg-common-test/references/star/${STAR_VERSION}/hg38" > /dev/null; then
     echo "Source location exists, continuing"
 else
     echo "Source location vacant, exiting"
@@ -14,11 +14,11 @@ else
 fi
 
 # check that the destination directory doesn't already exist
-echo "Checking gs://cpg-common-main/references/star/hg38/${STAR_VERSION}"
-if gcloud storage ls "gs://cpg-common-main/references/star/hg38/${STAR_VERSION}" > /dev/null; then
+echo "Checking gs://cpg-common-main/references/star/${STAR_VERSION}/hg38"
+if gcloud storage ls "gs://cpg-common-main/references/star/${STAR_VERSION}/hg38" > /dev/null; then
     echo "Target location already exists, will not replace"
     exit 1
 else
     echo "Target location vacant, copying"
-    gsutil rsync -r -m "gs://cpg-common-test/references/star/hg38/${STAR_VERSION}" "gs://cpg-common-main/references/star/hg38/${STAR_VERSION}"
+    gsutil rsync -r -m "gs://cpg-common-test/references/star/${STAR_VERSION}/hg38" "gs://cpg-common-main/references/star/${STAR_VERSION}/hg38"
 fi

--- a/star/prod_sync_script.sh
+++ b/star/prod_sync_script.sh
@@ -5,8 +5,8 @@
 STAR_VERSION=$1
 
 # check that the source location exists
-echo "Checking gs://cpg-common-test/references/star/${STAR_VERSION}/hg38"
-if gcloud storage ls "gs://cpg-common-test/references/star/${STAR_VERSION}/hg38" > /dev/null; then
+echo "Checking gs://cpg-common-main-tmp/references/star/${STAR_VERSION}/hg38"
+if gcloud storage ls "gs://cpg-common-main-tmp/references/star/${STAR_VERSION}/hg38" > /dev/null; then
     echo "Source location exists, continuing"
 else
     echo "Source location vacant, exiting"
@@ -20,5 +20,5 @@ if gcloud storage ls "gs://cpg-common-main/references/star/${STAR_VERSION}/hg38"
     exit 1
 else
     echo "Target location vacant, copying"
-    gsutil rsync -r -m "gs://cpg-common-test/references/star/${STAR_VERSION}/hg38" "gs://cpg-common-main/references/star/${STAR_VERSION}/hg38"
+    gsutil rsync -r -m "gs://cpg-common-main-tmp/references/star/${STAR_VERSION}/hg38" "gs://cpg-common-main/references/star/${STAR_VERSION}/hg38"
 fi

--- a/star/prod_sync_script.sh
+++ b/star/prod_sync_script.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env bash
+
+# a script for syncing tested STAR reference to the production bucket
+# takes a single argument for the STAR reference data to copy across
+STAR_VERSION=$1
+
+# check that the source location exists
+echo "Checking gs://cpg-common-test/references/star/hg38/${STAR_VERSION}"
+if gcloud storage ls "gs://cpg-common-test/references/star/hg38/${STAR_VERSION}" > /dev/null; then
+    echo "Source location exists, continuing"
+else
+    echo "Source location vacant, exiting"
+    exit 1
+fi
+
+# check that the destination directory doesn't already exist
+echo "Checking gs://cpg-common-main/references/star/hg38/${STAR_VERSION}"
+if gcloud storage ls "gs://cpg-common-main/references/star/hg38/${STAR_VERSION}" > /dev/null; then
+    echo "Target location already exists, will not replace"
+    exit 1
+else
+    echo "Target location vacant, copying"
+    gsutil rsync -r -m "gs://cpg-common-test/references/star/hg38/${STAR_VERSION}" "gs://cpg-common-main/references/star/hg38/${STAR_VERSION}"
+fi

--- a/star/star.toml
+++ b/star/star.toml
@@ -1,0 +1,4 @@
+[star]
+version = '2.7.10b'
+gencode_version = 44
+sjdb_overhang = 100


### PR DESCRIPTION
The `build_star_reference.py` script will take the broad reference FASTA file and download a Gencode GTF (version is specified in the config TOML when running through analysis runner). User also needs to specify the STAR version in the config TOML. The script will filter the FASTA and GTF for just the primary chromosomes and construct a STAR reference package. It will then write the reference package to `gs://cpg-common-test/references/star/<STAR_VERSION/hg38`.

Once the reference has been successfully generated and tested, the `prod_sync_script.sh` script can then be used to push the reference to the `gs://cpg-common-main/references/star/<STAR_VERSION>/hg38` bucket.