### PR TITLE
Fix rsync for pushing STAR ref to production

### DIFF
--- a/star/prod_sync_script.fa_gtf.sh
+++ b/star/prod_sync_script.fa_gtf.sh
@@ -16,5 +16,5 @@ if gcloud storage ls "gs://cpg-common-main/references/star/hg38" > /dev/null; th
     exit 1
 else
     echo "Target location vacant, copying"
-    gsutil rsync -r -m "gs://cpg-common-main-tmp/references/star/hg38" "gs://cpg-common-main/references/star/hg38"
+    gsutil -m rsync -r "gs://cpg-common-main-tmp/references/star/hg38" "gs://cpg-common-main/references/star/hg38"
 fi

--- a/star/prod_sync_script.star.sh
+++ b/star/prod_sync_script.star.sh
@@ -20,5 +20,5 @@ if gcloud storage ls "gs://cpg-common-main/references/star/${STAR_VERSION}/hg38"
     exit 1
 else
     echo "Target location vacant, copying"
-    gsutil rsync -r -m "gs://cpg-common-main-tmp/references/star/${STAR_VERSION}/hg38" "gs://cpg-common-main/references/star/${STAR_VERSION}/hg38"
+    gsutil -m rsync -r "gs://cpg-common-main-tmp/references/star/${STAR_VERSION}/hg38" "gs://cpg-common-main/references/star/${STAR_VERSION}/hg38"
 fi


### PR DESCRIPTION
It looks like the rsync commands in star/prod_sync_script.*.sh were wrong; the `-m` flag should be supplied to `gsutil`, not `rsync`.