### PR TITLE
add star reference cloud path to references.py

### DIFF
--- a/references.py
+++ b/references.py
@@ -328,5 +328,15 @@ SOURCES = [
             blacklist_sites='blacklist_sites.hg38.chrM.bed',
         ),
     ),
+    Source(
+        'star',
+        # References for STAR
+        dst='star',
+        files=dict(
+            ref_dir='2.7.10b/hg38',
+            gtf='hg38/hg38.gtf',
+            fasta='hg38/hg38.fa'
+        ),
+    ),
 
 ]


### PR DESCRIPTION
Added the STAR reference package and associated GTF and FASTA files to the references.py script. The current STAR reference version is `2.7.10b`. This should create a new section in the references TOML like so:

```toml
[references.star]
ref_dir = "gs://cpg-common-main/references/star/2.7.10b/hg38"
gtf = "gs://cpg-common-main/references/star/hg38/hg38.gtf"
fasta = "gs://cpg-common-main/references/star/hg38/hg38.fa"
```

Because the STAR reference is created and pushed to the production bucket by separate scripts (`star/build_star_reference.py`, `star/prod_sync_script.star.sh`, and `star/prod_sync_script.fa_gtf.sh`), the new `Source` object in `references.py` only contains a `dst` and `files` parameter, but no `src` parameter.