### PR TITLE
Add sites table for PCA

### DIFF
--- a/references.py
+++ b/references.py
@@ -338,7 +338,7 @@ SOURCES = [
             fasta='hg38/hg38.fa'
         ),
     ),
-        Source(
+    Source(
         'representative_sites_table',
         # representative sites table for PCA
         # generated using the HGDP+1KG dataset

--- a/references.py
+++ b/references.py
@@ -339,7 +339,7 @@ SOURCES = [
         ),
     ),
     Source(
-        'representative_sites_table',
+        'ancestry',
         # representative sites table for PCA
         # generated using the HGDP+1KG dataset
         dst='ancestry',

--- a/references.py
+++ b/references.py
@@ -338,5 +338,14 @@ SOURCES = [
             fasta='hg38/hg38.fa'
         ),
     ),
+        Source(
+        'representative_sites_table',
+        # representative sites table for PCA
+        # generated using the HGDP+1KG dataset
+        dst='ancestry',
+        files=dict(
+            sites_table='pruned_variants.ht',
+        ),
+    ),
 
 ]

--- a/sites_table/README.md
+++ b/sites_table/README.md
@@ -1,0 +1,14 @@
+# HGDP + 1KG reference sites table
+
+This sites table is a representative subset of variants, generated from the publicly-available HGDP + 1KG dataset. Site selection is based off of the following criteria: sites are biallelic, autosomal, have an allele frequency above 1%, have a call rate above 99%, and have an inbreeding coefficient > -0.25 (this selection criteria is based predominantly off of the [gnomAD selection criteria](https://macarthurlab.org/2018/10/17/gnomad-v2-1/), with the exception that variants can be present in exomes or genomes).
+
+This table can be used to generate a PCA for other highly divergent datasets, as tests conducted at the CPG showed little difference between sites selected from HGDP + 1KG compared to sites selected using HGDP + 1KG + other diverse cohorts.
+
+The code used to generate this table can be found [here](https://github.com/populationgenomics/cpg-methods/tree/main/scripts/hgdp_1kg_marker_selection; see Hail batch [423327](https://batch.hail.populationgenomics.org.au/batches/423327/jobs/2) for log info).
+
+The sites table can be found in `gs://cpg-common-main/references/ancestry/` and was copied from the `hgdp-1kg-main` bucket using the following command:
+
+```bash
+analysis-runner --dataset reference --access-level full --output-dir "references/ancestry" --description "copy sites table" sites_table/copy_sites_table.sh 
+```
+

--- a/sites_table/copy_sites_table.sh
+++ b/sites_table/copy_sites_table.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env bash
+
+set -ex
+
+gsutil -m cp gs://cpg-hgdp-1kg-main/sites_table/v1-0/pruned_variants.ht gs://cpg-common-main/references/ancestry/


### PR DESCRIPTION
Add a table of representative sites to conduct PCA on datasets, e.g., within the ancestry stage of the large cohort pipeline. 