### PR TITLE
Add the hg38 telomeres and centromeres bed from gnomAD v3

### DIFF
--- a/references.py
+++ b/references.py
@@ -400,6 +400,11 @@ SOURCES = [
             remm_tsv='ReMM.v0.3.1.post1.hg38.tsv.gz',
             remm_index='ReMM.v0.3.1.post1.hg38.tsv.gz.tbi',
         ),
+    ),
+    Source(
+        'hg38_telomeres_and_centromeres',
+        # gnomAD v3 hg38 coordinates for telomeres and centromeres
+        src='gs://gcp-public-data--gnomad/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.bed',
+        dst='hg38/v0/hg38.telomeresAndMergedCentromeres.bed'
     )
-
 ]


### PR DESCRIPTION
Adding the bed file that gnomAD v3 used to exclude telomeres and centromeres.

From: https://github.com/broadinstitute/gnomad_methods/blob/main/gnomad/resources/grch38/reference_data.py#L359