### PR TITLE
Stringify the reference_path

### DIFF
--- a/reference_generating_scripts/convert_bed_to_interval_list.py
+++ b/reference_generating_scripts/convert_bed_to_interval_list.py
@@ -40,7 +40,7 @@ def main(bed_ref, sd_ref, out_ref):
     Converts a BED file to a .interval_list file using Picard BedToIntervalList.
     The output file must have been added to references.py.
     """
-    out_ref = reference_path(out_ref)
+    out_ref = str(reference_path(out_ref))
     if not out_ref.endswith('.interval_list'):
         raise ValueError('Output reference file must have a .interval_list extension.')
     get_ref_files(bed_ref, sd_ref, out_ref)


### PR DESCRIPTION
I messed this up because the reference_path function outputs a GSPath which [doesn't work](https://batch.hail.populationgenomics.org.au/batches/442121/jobs/1) with a lot of what's going on in the script. 

Convert it to a string to [resolve everything](https://batch.hail.populationgenomics.org.au/batches/442150/jobs/1) (the batch only fails at the end as it tries to write to main, which is forbidden for the test SA.)