### PR TITLE
Update gnomAD v3 hg38 bed file reference

### DIFF
--- a/reference_generating_scripts/convert_bed_to_interval_list.py
+++ b/reference_generating_scripts/convert_bed_to_interval_list.py
@@ -32,7 +32,7 @@ def get_ref_files(bed_ref: str, sd_ref: str, outfile_path: str) -> None:
     
     
 @click.command()
-@click.option('--bed-ref', required=True, help='String identifier for the BED file from the references.', default='hg38_telomeres_and_centromeres')
+@click.option('--bed-ref', required=True, help='String identifier for the BED file from the references.', default='gnomad/tel_and_cent_bed')
 @click.option('--sd-ref', required=True, help='String identifier for the sequence dictionary file from the references.', default='broad/genome_calling_interval_lists')
 @click.option('--out-ref', required=True, help='Reference path to save the output .interval_list file.', default='hg38_telomeres_and_centromeres_intervals/interval_list')
 def main(bed_ref, sd_ref, out_ref):

--- a/references.py
+++ b/references.py
@@ -209,6 +209,7 @@ SOURCES = [
         transfer_cmd=gcs_cp_r,
         files=dict(
             tel_and_cent_ht='telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.ht',
+            tel_and_cent_bed='telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.bed',
             lcr_intervals_ht='lcr_intervals/LCRFromHengHg38.ht',
             seg_dup_intervals_ht='seg_dup_intervals/GRCh38_segdups.ht',
             clinvar_ht='clinvar/clinvar_20190923.ht',
@@ -402,13 +403,6 @@ SOURCES = [
             remm_tsv='ReMM.v0.3.1.post1.hg38.tsv.gz',
             remm_index='ReMM.v0.3.1.post1.hg38.tsv.gz.tbi',
         ),
-    ),
-    Source(
-        'hg38_telomeres_and_centromeres',
-        # gnomAD v3 hg38 coordinates for telomeres and centromeres
-        src='gs://gcp-public-data--gnomad/resources/grch38/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.bed',
-        dst='hg38/v0/hg38.telomeresAndMergedCentromeres.bed',
-        transfer_cmd=gcs_cp_r,
     ),
     Source(
         'hg38_telomeres_and_centromeres_intervals',


### PR DESCRIPTION
The hg38 telomeres and centromeres bed file that was added in #49 is a duplicate of an existing file in the gnomad references, found at 
`gs://cpg-common-main/references/gnomad/v0/telomeres_and_centromeres/hg38.telomeresAndMergedCentromeres.bed`. 
I didn't realise it was there when I opened #49 because it wasn't in references.py in this repo alongside the other gnomad reference files. 

This PR updates the Source of the bed file so that it's grouped with the other `gnomad` references, specifically with the `hg38.telomeresAndMergedCentromeres.ht` reference since they are from the same directory of the gnomAD public resources: `gs://gcp-public-data--gnomad/resources/grch38/telomeres_and_centromeres/`.

- The change to `convert_bed_to_interval_list.py` updates the bed reference string, mostly just for consistency in documenting the origin of the interval_list reference `hg38_telomeres_and_centromeres_intervals`.

Thanks @hopedisastro for pointing this out.