### PR TITLE
Add gnomAD v4.1 reference VCFs and HT

### DIFF
--- a/references.py
+++ b/references.py
@@ -459,7 +459,7 @@ SOURCES = [
     ),
     Source(
         'gnomad_4.1_vcfs',
-        src='gs://gcp-public-data--gnomad/release/4.1/vcf/genomes/        ',
+        src='gs://gcp-public-data--gnomad/release/4.1/vcf/genomes',
         dst='gnomad/v4.1/vcfs',
         files={contig: f'gnomad.genomes.r4.1.sites.{contig}.vcf.bgz' for contig in CANONICAL_CHROMOSOMES},
         transfer_cmd=gcs_rsync,


### PR DESCRIPTION
- adds gnomAD v4.1 VCFs and HT
  - HT can be used in annotating main pipeline data
  - VCFs will be used in a Talos workflow, foundational to making Talos redeployable at other sites
- adds gnomad v3.1 Mito VCF (not available in gnomad 4)
- adds a new transfer mechanic, for copying a single file (the Mito frequencies are only available in 3.1, but we don't really want or need the rest of the 3.1 files, so only copy this single one)

n.b. these VCFs and tables are huge, containing LOADS of fields. The plan here is to pull them as they currently exist, then make a minimised version of the VCFs for use in annotation (e.g. only retaining general AC/AN/AF/HomCount etc., instead of keeping additional results per population). This will lead to greatly reduced runtimes and resource requirements when using these as annotation sources. 

That can't really be done in this repo, so that is a follow-up work item