### PR TITLE
Fix canonical contigs

### DIFF
--- a/references.py
+++ b/references.py
@@ -6,7 +6,7 @@ import dataclasses
 from shlex import quote
 from typing import Protocol
 
-CANONICAL_CHROMOSOMES = [f'chr{x}' for x in list(range(1, 23))] + ['X', 'Y']
+CANONICAL_CHROMOSOMES = [f'chr{x}' for x in list(range(1, 23)) + ['X', 'Y']]
 
 
 class SyncCommandProtocol(Protocol):


### PR DESCRIPTION
Left a little bug in here - X & Y aren't prefixed with `chr` in the config. I don't think this should attempt to re-copy the files. 

The inclusion of a full stop in the `4.1` lead to all these being quoted in the config file. I should have seen that coming, given that TOML separates config levels with full stops.
<img width="296" alt="Screenshot 2025-02-21 at 1 10 13 PM" src="https://github.com/user-attachments/assets/0de832bc-b3b3-4b5c-816f-9e239d105a54" />

I'm going to leave that in, as it doesn't affect our ability to use the config. Changing this to `4_1` would trigger a re-copy as the source name would change.

In individual workflows we can point to these using whichever config keys we want. It's important that we have them copied into our infra
