### PR TITLE
Add additional Talos/Reannotation resources

### DIFF
--- a/reference_generating_scripts/alphamissense_formatting.py
+++ b/reference_generating_scripts/alphamissense_formatting.py
@@ -58,11 +58,21 @@ def filter_for_pathogenic_am(input_file: str, intermediate_file: str):
         intermediate_file ():
     """
 
-    headers = ['chrom', 'pos', 'ref', 'alt', 'transcript', 'am_pathogenicity', 'am_class']
+    headers = [
+        'chrom',
+        'pos',
+        'ref',
+        'alt',
+        'transcript',
+        'am_pathogenicity',
+        'am_class',
+    ]
 
     # empty dictionary to contain the target indexes
     header_indexes: dict[str, int] = {}
-    with gzip.open(input_file, 'rt') as read_handle, open(intermediate_file, 'wt') as write_handle:
+    with gzip.open(input_file, 'rt') as read_handle, open(
+        intermediate_file, 'wt'
+    ) as write_handle:
         for line in read_handle:
             # skip over the headers
             if line.startswith('#'):
@@ -81,7 +91,9 @@ def filter_for_pathogenic_am(input_file: str, intermediate_file: str):
             content = line.rstrip().split()
 
             # grab all the content
-            content_dict: dict[str, str | float] = {key: content[header_indexes[key]] for key in headers}
+            content_dict: dict[str, str | float] = {
+                key: content[header_indexes[key]] for key in headers
+            }
 
             # trim transcripts
             assert isinstance(content_dict['transcript'], str)
@@ -122,7 +134,9 @@ def json_to_hail_table(json_file: str, ht_out: str):
     ht = ht.transmute(**ht.f0)
 
     # combine the two alleles into a single list
-    ht = ht.transmute(locus=hl.locus(contig=ht.chrom, pos=ht.pos), alleles=[ht.ref, ht.alt])
+    ht = ht.transmute(
+        locus=hl.locus(contig=ht.chrom, pos=ht.pos), alleles=[ht.ref, ht.alt]
+    )
     ht = ht.key_by('locus', 'alleles')
     ht.write(ht_out)
     ht.describe()

--- a/reference_generating_scripts/alphamissense_manager.sh
+++ b/reference_generating_scripts/alphamissense_manager.sh
@@ -2,7 +2,10 @@
 
 # This script is used to manage the generation of reference files for the alpha missense dataset.
 
-WRITE_OUTPUT_TO="gs://cpg-common-main/references/alphamissense"
+# destination for the output
+MAIN_OR_TEST=${1:-"main"}
+
+WRITE_OUTPUT_TO="gs://cpg-common-${MAIN_OR_TEST}/references/alphamissense"
 
 # wget the raw data
 AM_ZENODO="https://zenodo.org/records/8208688/files/AlphaMissense_hg38.tsv.gz"
@@ -12,7 +15,7 @@ wget -q -O alphamissense_38.tsv.gz $AM_ZENODO
 
 # copy it up to GCP
 TSV_DESTINATION="${WRITE_OUTPUT_TO}/alphamissense_38.tsv.gz"
-gcloud storage cp --do-not-decompress alphamissense_38.tsv.gz $TSV_DESTINATION
+gcloud storage cp --do-not-decompress alphamissense_38.tsv.gz "$TSV_DESTINATION"
 
 # convert the TSV to a HT
 python3 reference_generating_scripts/alphamissense_formatting.py \
@@ -21,10 +24,10 @@ python3 reference_generating_scripts/alphamissense_formatting.py \
 
 # copy that up to GCP
 TABLE_DESTINATION="${WRITE_OUTPUT_TO}/alphamissense_38.ht"
-gcloud --quiet storage cp -r alphamissense_38.ht $TABLE_DESTINATION
+gcloud --quiet storage cp -r alphamissense_38.ht "$TABLE_DESTINATION"
 
 # compress the output, write as a single file (easier to localise)
 tar -czf alphamissense_38.ht.tar.gz alphamissense_38.ht
 
 TAR_DESTINATION="${WRITE_OUTPUT_TO}/alphamissense_38.ht.tar.gz"
-gcloud --quiet storage cp alphamissense_38.ht.tar.gz $TAR_DESTINATION
+gcloud --quiet storage cp alphamissense_38.ht.tar.gz "$TAR_DESTINATION"

--- a/reference_generating_scripts/alphamissense_manager.sh
+++ b/reference_generating_scripts/alphamissense_manager.sh
@@ -27,4 +27,4 @@ gcloud --quiet storage cp -r alphamissense_38.ht $TABLE_DESTINATION
 tar -czf alphamissense_38.ht.tar.gz alphamissense_38.ht
 
 TAR_DESTINATION="${WRITE_OUTPUT_TO}/alphamissense_38.ht.tar.gz"
-gcloud --quiet storage cp alphamissense_38.ht $TAR_DESTINATION
+gcloud --quiet storage cp alphamissense_38.ht.tar.gz $TAR_DESTINATION

--- a/reference_generating_scripts/convert_bed_to_interval_list.py
+++ b/reference_generating_scripts/convert_bed_to_interval_list.py
@@ -7,14 +7,14 @@ def get_ref_files(bed_ref: str, sd_ref: str, outfile_path: str) -> None:
     """
     Converts a BED file to a .interval_list file using Picard BedToIntervalList.
     Saves the .interval_list file to the reference directory with the specified outfile name.
-    """  
+    """
     bed_file = reference_path(bed_ref)
     sd_file = reference_path(sd_ref)
-    
+
     b = get_batch()
     j = b.new_job(f'Convert {bed_file} to .interval_list file')
     j.image(image_path('picard'))
-    
+
     cmd = f"""
     mkdir $BATCH_TMPDIR/out
     
@@ -25,16 +25,31 @@ def get_ref_files(bed_ref: str, sd_ref: str, outfile_path: str) -> None:
     
     ln $BATCH_TMPDIR/out/outfile.interval_list {j['interval_list']}
     """
-    
+
     j.command(command(cmd))
     b.write_output(j['interval_list'], outfile_path)
     b.run()
-    
-    
+
+
 @click.command()
-@click.option('--bed-ref', required=True, help='String identifier for the BED file from the references.', default='gnomad/tel_and_cent_bed')
-@click.option('--sd-ref', required=True, help='String identifier for the sequence dictionary file from the references.', default='broad/genome_calling_interval_lists')
-@click.option('--out-ref', required=True, help='Reference path to save the output .interval_list file.', default='hg38_telomeres_and_centromeres_intervals/interval_list')
+@click.option(
+    '--bed-ref',
+    required=True,
+    help='String identifier for the BED file from the references.',
+    default='gnomad/tel_and_cent_bed',
+)
+@click.option(
+    '--sd-ref',
+    required=True,
+    help='String identifier for the sequence dictionary file from the references.',
+    default='broad/genome_calling_interval_lists',
+)
+@click.option(
+    '--out-ref',
+    required=True,
+    help='Reference path to save the output .interval_list file.',
+    default='hg38_telomeres_and_centromeres_intervals/interval_list',
+)
 def main(bed_ref, sd_ref, out_ref):
     """
     Converts a BED file to a .interval_list file using Picard BedToIntervalList.

--- a/reference_generating_scripts/encode_files_using_echtvar.py
+++ b/reference_generating_scripts/encode_files_using_echtvar.py
@@ -86,7 +86,11 @@ def encode_gnomad() -> None:
     we need to do this once ever, estimated cost $5
     """
 
-    common_folder = join(config_retrieve(['storage', 'common', 'default']), 'gnomad', 'echtvar')
+    common_folder = join(
+        config_retrieve(['storage', 'common', 'default']),
+        'gnomad',
+        'echtvar',
+    )
     output_template = join(common_folder, 'gnomad_4.1_{chrom}.zip')
 
     contig_files = []

--- a/reference_generating_scripts/encode_files_using_echtvar.py
+++ b/reference_generating_scripts/encode_files_using_echtvar.py
@@ -210,7 +210,8 @@ def encode_gnomad(region: str | None = None) -> None:
             f'Running echtvar on whole genome, Region: {region or "unrestricted"}'
         )
         job = get_batch().new_job(
-            f'Run echtvar on gnomad v4.1, whole genome, Region: {region or "unrestricted"}'
+            f'Run echtvar on gnomad v4.1, whole genome, Region: {region or "unrestricted"}',
+            attributes={'tool': 'bcftools'},
         )
         job.image(echtvar_image)
         job.storage(f'{storage_running_total}Gi')

--- a/reference_generating_scripts/encode_files_using_echtvar.py
+++ b/reference_generating_scripts/encode_files_using_echtvar.py
@@ -265,7 +265,7 @@ def encode_anything(input_list: list[str], output: str, region: str | None = Non
             localised_region = get_batch().read_input(region)
             # if we only want to run on a subset of the genome, read in the BED file
             trim_job = get_batch().new_bash_job(
-                f'Trim {input_file} to specified region'
+                f'Trim {input_file} to specified region', attributes={'tool': 'bcftools'}
             )
             trim_job.image(bcftools_image)
             trim_job.storage(f'{input_size}Gi')
@@ -283,7 +283,7 @@ def encode_anything(input_list: list[str], output: str, region: str | None = Non
         total_storage += input_size
 
     # create a job to run echtvar on all the input VCFs
-    job = get_batch().new_job('Run echtvar on all input VCFs')
+    job = get_batch().new_job('Run echtvar on all input VCFs', attributes={'tool': 'echtvar'})
     job.image(echtvar_image)
     job.storage(f'{total_storage}Gi')
     job.cpu(4)

--- a/reference_generating_scripts/encode_files_using_echtvar.py
+++ b/reference_generating_scripts/encode_files_using_echtvar.py
@@ -86,7 +86,7 @@ def encode_gnomad() -> None:
     we need to do this once ever, estimated cost $5
     """
 
-    common_folder = join(config_retrieve(['storage', 'common']), 'gnomad', 'echtvar')
+    common_folder = join(config_retrieve(['storage', 'common', 'default']), 'gnomad', 'echtvar')
     output_template = join(common_folder, 'gnomad_4.1_{chrom}.zip')
 
     contig_files = []

--- a/reference_generating_scripts/generate_bed_from_ensembl.py
+++ b/reference_generating_scripts/generate_bed_from_ensembl.py
@@ -1,0 +1,184 @@
+#!/usr/bin/env python3
+
+"""
+Parses a GFF3 file, and generates a BED file of gene regions, plus padding, generating the following columns:
+- chrom
+- start
+- end
+- gene details
+"""
+
+
+import gzip
+import re
+from argparse import ArgumentParser
+
+
+CHROM_INDEX = 0
+RESOURCE_INDEX = 1
+TYPE_INDEX = 2
+START_INDEX = 3
+END_INDEX = 4
+DETAILS_INDEX = 8
+
+# +/- this is added to each gene region, this default can be overridden
+FLANKING_REGION = 2000
+
+# regular expressions to parse out sections of the GFF3 annotations
+GENE_ID_RE = re.compile(r'ID=gene:(ENSG\d+);')
+GENE_NAME_RE = re.compile(r'Name=([\w-]+);')
+
+
+def main(
+    gff3_file: str, unmerged_output: str, merged_output: str, flanking: int = 2000
+):
+    """
+    Read the GFF3 file, and generate a BED file of gene regions, plus padding
+    Args:
+        gff3_file (str): path to the GFF3 file
+        unmerged_output (str): path to the intended BED output file
+        merged_output (str): path to generate a BED file with merged overlapping rows
+        flanking (int): number of bases to add before and after each gene
+    """
+
+    unmerged_lines = generate_bed_lines(gff3_file, unmerged_output, flanking)
+    merge_output(unmerged_lines, merged_output)
+
+
+def generate_bed_lines(
+    gff3_file: str,
+    output: str,
+    flanking: int = FLANKING_REGION,
+) -> list[tuple[str, int, int]]:
+    """
+    generate the new BED file, and return the lines as a list of lists for merging
+    """
+    output_lines: list[tuple[str, int, int]] = []
+    # open and iterate over the GFF3 file
+    with gzip.open(gff3_file, 'rt') as handle, open(output, 'w') as write_handle:
+        for line in handle:
+            # skip over headers and dividing lines
+            if line.startswith('#'):
+                continue
+
+            line_as_list = line.rstrip().split('\t')
+
+            # skip over non-genes (e.g. pseudogenes, ncRNA)
+            # only focus on Ensembl genes/transcripts
+            if (
+                line_as_list[TYPE_INDEX] != 'gene'
+                or 'ensembl' not in line_as_list[RESOURCE_INDEX]
+            ):
+                continue
+
+            # extract the gene name from the details field
+            # allowing for some situations that don't work,
+            # e.g. ENSG00000225931 (novel transcript, to be experimentally confirmed)
+            # search for ID and transcript separately, ordering not guaranteed
+            try:
+                gene_name = GENE_NAME_RE.search(line_as_list[DETAILS_INDEX]).group(1)
+                gene_id = GENE_ID_RE.search(line_as_list[DETAILS_INDEX]).group(1)
+            except AttributeError:
+                print(f'Failed to extract gene name from {line_as_list[DETAILS_INDEX]}')
+                continue
+
+            # write the line to the output
+            output_list = [
+                f'chr{line_as_list[CHROM_INDEX]}',
+                str(int(line_as_list[START_INDEX]) - flanking),
+                str(int(line_as_list[END_INDEX]) + flanking),
+                f'{gene_id};{gene_name}',
+            ]
+            write_handle.write('\t'.join(output_list) + '\n')
+            output_lines.append(
+                (
+                    f'chr{line_as_list[CHROM_INDEX]}',
+                    int(line_as_list[START_INDEX]) - flanking,
+                    int(line_as_list[END_INDEX]) + flanking,
+                )
+            )
+    return output_lines
+
+
+def merge_output(
+    unmerged_lines: list[tuple[str, int, int]],
+    output: str,
+    flanking: int = FLANKING_REGION,
+):
+    """
+    take the lines, resolve overlapping regions, and write out to a new file
+
+    Args:
+        unmerged_lines (list): input of region-per-gene lines
+        output (str): filepath to generate
+        flanking (int): merge regions within this distance
+
+    Returns:
+
+    """
+    contig = None
+    start = None
+    end = None
+    with open(output, 'wt') as handle:
+        for this_chrom, this_start, this_end in unmerged_lines:
+            if contig is None:
+                contig = this_chrom
+                start = this_start
+                end = this_end
+                continue
+
+            # change in contig = write the previous block, and reset values
+            if this_chrom != contig:
+                handle.write(f'{contig}\t{start}\t{end}\n')
+                contig = this_chrom
+                start = this_start
+                end = this_end
+                continue
+
+            # adjacent blocks close enough, merge them, but don't write
+            if this_start - end < flanking:
+                end = this_end
+
+            # far enough apart, write the previous block and reset
+            else:
+                handle.write(f'{contig}\t{start}\t{end}\n')
+                start = this_start
+                end = this_end
+
+        # and write the final line
+        handle.write(f'{contig}\t{start}\t{end}\n')
+
+
+def cli_main():
+    parser = ArgumentParser()
+    parser.add_argument(
+        '--gff3',
+        help='Path to the compressed GFF3 file',
+        required=True,
+    )
+    parser.add_argument(
+        '--unmerged_output',
+        help='Path to output file, one line per gene with IDs',
+        required=True,
+    )
+    parser.add_argument(
+        '--merged_output',
+        help='Path to output file, regions merged',
+        required=False,
+    )
+    parser.add_argument(
+        '--flanking',
+        help='Regions to add to each gene',
+        default=FLANKING_REGION,
+    )
+    args = parser.parse_args()
+    main(
+        gff3_file=args.gff3,
+        unmerged_output=args.unmerged_output,
+        merged_output=args.merged_output,
+        flanking=args.flanking,
+    )
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/reference_generating_scripts/generate_bed_from_ensembl.py
+++ b/reference_generating_scripts/generate_bed_from_ensembl.py
@@ -25,8 +25,10 @@ DETAILS_INDEX = 8
 FLANKING_REGION = 2000
 
 # regular expressions to parse out sections of the GFF3 annotations
-GENE_ID_RE = re.compile(r'ID=gene:(ENSG\d+);')
+GENE_ID_RE = re.compile(r'gene:(ENSG\d+);')
 GENE_NAME_RE = re.compile(r'Name=([\w-]+);')
+
+TYPES_TO_KEEP: set[str] = {'gene', 'ncRNA_gene', 'snRNA'}
 
 
 def main(
@@ -66,7 +68,7 @@ def generate_bed_lines(
             # skip over non-genes (e.g. pseudogenes, ncRNA)
             # only focus on Ensembl genes/transcripts
             if (
-                line_as_list[TYPE_INDEX] != 'gene'
+                line_as_list[TYPE_INDEX] not in TYPES_TO_KEEP
                 or 'ensembl' not in line_as_list[RESOURCE_INDEX]
             ):
                 continue

--- a/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
+++ b/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
@@ -2,7 +2,6 @@
 
 # This script is used to manage the generation of a BED file from the ensembl GFF3
 
-
 # first identify the location of the ensembl GFF3 based on its version
 ENSEMBL_VERSION=${1:-"113"}
 GFF3_URL="https://ftp.ensembl.org/pub/release-${ENSEMBL_VERSION}/gff3/homo_sapiens/Homo_sapiens.GRCh38.${ENSEMBL_VERSION}.gff3.gz"

--- a/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
+++ b/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
@@ -17,12 +17,14 @@ wget "${GFF3_URL}" -O "${LOCAL_OUTPUT_GFF3}"
 # parse that gff3 into a BED file
 python3 reference_generating_scripts/generate_bed_from_ensembl.py \
     --gff3 "${LOCAL_OUTPUT_GFF3}" \
-    --unmerged_output "${LOCAL_OUTPUT_BED}" \
-    --merged_output "${MERGED_OUTPUT_BED}"
+    --unmerged_output unmerged.bed \
+    --merged_output merged.bed
 
 ## sort and merge the result - local script in lieu of using BedTools (not installed here)
-## commented out, the initial file is already accurately position-sorted
-#sort -k1,1 -k2,2n "${LOCAL_OUTPUT_BED}" > "${SORTED_OUTPUT_BED}"
+## -k1,1V: Version sort to get chr ordering correct
+## -k2,2n: numerical sort on col 2
+sort -k1,1V -k2,2n unmerged.bed > "${LOCAL_OUTPUT_BED}"
+sort -k1,1V -k2,2n merged.bed > "${MERGED_OUTPUT_BED}"
 
 # copy all the content to GCP - keep the same file names, copy in bulk
 WRITE_OUTPUT_TO="gs://cpg-common-main/references/ensembl_${ENSEMBL_VERSION}"

--- a/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
+++ b/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
@@ -2,7 +2,6 @@
 
 # This script is used to manage the generation of a BED file from the ensembl GFF3
 
-# destination for the output
 
 # first identify the location of the ensembl GFF3 based on its version
 ENSEMBL_VERSION=${1:-"113"}
@@ -10,6 +9,9 @@ GFF3_URL="https://ftp.ensembl.org/pub/release-${ENSEMBL_VERSION}/gff3/homo_sapie
 LOCAL_OUTPUT_GFF3="GRCh38.gff3.gz"
 LOCAL_OUTPUT_BED="GRCh38.bed"
 MERGED_OUTPUT_BED="merged_GRCh38.bed"
+
+# destination for the output
+MAIN_OR_TEST=${2:-"main"}
 
 # get that
 wget "${GFF3_URL}" -O "${LOCAL_OUTPUT_GFF3}"
@@ -27,7 +29,7 @@ sort -k1,1V -k2,2n unmerged.bed > "${LOCAL_OUTPUT_BED}"
 sort -k1,1V -k2,2n merged.bed > "${MERGED_OUTPUT_BED}"
 
 # copy all the content to GCP - keep the same file names, copy in bulk
-WRITE_OUTPUT_TO="gs://cpg-common-main/references/ensembl_${ENSEMBL_VERSION}"
+WRITE_OUTPUT_TO="gs://cpg-common-${MAIN_OR_TEST}/references/ensembl_${ENSEMBL_VERSION}"
 #GFF3_DESTINATION="${WRITE_OUTPUT_TO}/${LOCAL_OUTPUT_GFF3}"
 #UNMERGED_BED_DESTINATION="${WRITE_OUTPUT_TO}/${LOCAL_OUTPUT_BED}"
 #MERGED_BED_DESTINATION="${WRITE_OUTPUT_TO}/${MERGED_OUTPUT_BED}"

--- a/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
+++ b/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+
+# This script is used to manage the generation of a BED file from the ensembl GFF3
+
+# destination for the output
+
+# first identify the location of the ensembl GFF3 based on its version
+ENSEMBL_VERSION=${1:-"113"}
+GFF3_URL="https://ftp.ensembl.org/pub/release-${ENSEMBL_VERSION}/gff3/homo_sapiens/Homo_sapiens.GRCh38.${ENSEMBL_VERSION}.gff3.gz"
+LOCAL_OUTPUT_GFF3="GRCh38.gff3.gz"
+LOCAL_OUTPUT_BED="GRCh38.bed"
+MERGED_OUTPUT_BED="merged_GRCh38.bed"
+
+# get that
+wget "${GFF3_URL}" -O "${LOCAL_OUTPUT_GFF3}"
+
+# parse that gff3 into a BED file
+python3 reference_generating_scripts/generate_bed_from_ensembl.py \
+    --gff3 "${LOCAL_OUTPUT_GFF3}" \
+    --unmerged_output "${LOCAL_OUTPUT_BED}" \
+    --merged_output "${MERGED_OUTPUT_BED}"
+
+## sort and merge the result - local script in lieu of using BedTools (not installed here)
+## commented out, the initial file is already accurately position-sorted
+#sort -k1,1 -k2,2n "${LOCAL_OUTPUT_BED}" > "${SORTED_OUTPUT_BED}"
+
+# copy all the content to GCP - keep the same file names, copy in bulk
+WRITE_OUTPUT_TO="gs://cpg-common-main/references/ensembl_${ENSEMBL_VERSION}"
+#GFF3_DESTINATION="${WRITE_OUTPUT_TO}/${LOCAL_OUTPUT_GFF3}"
+#UNMERGED_BED_DESTINATION="${WRITE_OUTPUT_TO}/${LOCAL_OUTPUT_BED}"
+#MERGED_BED_DESTINATION="${WRITE_OUTPUT_TO}/${MERGED_OUTPUT_BED}"
+
+gcloud storage cp --do-not-decompress \
+    "${LOCAL_OUTPUT_GFF3}" "${LOCAL_OUTPUT_BED}" "${MERGED_OUTPUT_BED}" \
+    "${WRITE_OUTPUT_TO}"

--- a/reference_generating_scripts/mane_summary_manager.sh
+++ b/reference_generating_scripts/mane_summary_manager.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+
+# first identify the location of the MANE summary based on the version
+MANE_VERSION=${1:-"1.4"}
+MANE_URL="https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/release_${MANE_VERSION}/MANE.GRCh38.v${MANE_VERSION}.summary.txt.gz"
+LOCAL_SUMMARY_NAME="mane_{MANE_VERSION}.summary.txt.gz"
+# download that file to a slightly simplified name
+wget "${MANE_URL}" -O "${LOCAL_SUMMARY_NAME}"
+
+# generate the JSON summary file
+python3 reference_generating_scripts/mane_summary_parser.py \
+    --input "${LOCAL_SUMMARY_NAME}" \
+    --output "mane_{MANE_VERSION}.json" \
+    --format json
+
+# copy all the content to GCP - keep the same file names, copy in bulk
+DESTINATION="gs://cpg-common-main/references/mane_${ENSEMBL_VERSION}"
+DESTINATION_JSON="${DESTINATION}/mane_{MANE_VERSION}.json"
+DESTINATION_SUMMARY="${DESTINATION}/${LOCAL_SUMMARY_NAME}"
+
+gcloud storage cp "mane_{MANE_VERSION}.json" "${DESTINATION_JSON}"
+gcloud storage cp "${LOCAL_SUMMARY_NAME}" "${DESTINATION_SUMMARY}"

--- a/reference_generating_scripts/mane_summary_manager.sh
+++ b/reference_generating_scripts/mane_summary_manager.sh
@@ -3,23 +3,23 @@
 # first identify the location of the MANE summary based on the version
 MANE_VERSION=${1:-"1.4"}
 MANE_URL="https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/release_${MANE_VERSION}/MANE.GRCh38.v${MANE_VERSION}.summary.txt.gz"
-LOCAL_SUMMARY_NAME="mane_{MANE_VERSION}.summary.txt.gz"
+LOCAL_SUMMARY_NAME="mane_${MANE_VERSION}.summary.txt.gz"
 # download that file to a slightly simplified name
 wget "${MANE_URL}" -O "${LOCAL_SUMMARY_NAME}"
 
 # generate the JSON summary file
 python3 reference_generating_scripts/mane_summary_parser.py \
     --input "${LOCAL_SUMMARY_NAME}" \
-    --output "mane_{MANE_VERSION}.json" \
+    --output "mane_${MANE_VERSION}.json" \
     --format json
 
 # destination for the output
 MAIN_OR_TEST=${2:-"main"}
 
 # copy all the content to GCP - keep the same file names, copy in bulk
-DESTINATION="gs://cpg-common-${MAIN_OR_TEST}/references/mane_${ENSEMBL_VERSION}"
-DESTINATION_JSON="${DESTINATION}/mane_{MANE_VERSION}.json"
+DESTINATION="gs://cpg-common-${MAIN_OR_TEST}/references/mane_${MANE_VERSION}"
+DESTINATION_JSON="${DESTINATION}/mane_${MANE_VERSION}.json"
 DESTINATION_SUMMARY="${DESTINATION}/${LOCAL_SUMMARY_NAME}"
 
-gcloud storage cp "mane_{MANE_VERSION}.json" "${DESTINATION_JSON}"
+gcloud storage cp "mane_${MANE_VERSION}.json" "${DESTINATION_JSON}"
 gcloud storage cp "${LOCAL_SUMMARY_NAME}" "${DESTINATION_SUMMARY}"

--- a/reference_generating_scripts/mane_summary_manager.sh
+++ b/reference_generating_scripts/mane_summary_manager.sh
@@ -13,8 +13,11 @@ python3 reference_generating_scripts/mane_summary_parser.py \
     --output "mane_{MANE_VERSION}.json" \
     --format json
 
+# destination for the output
+MAIN_OR_TEST=${1:-"main"}
+
 # copy all the content to GCP - keep the same file names, copy in bulk
-DESTINATION="gs://cpg-common-main/references/mane_${ENSEMBL_VERSION}"
+DESTINATION="gs://cpg-common-${MAIN_OR_TEST}/references/mane_${ENSEMBL_VERSION}"
 DESTINATION_JSON="${DESTINATION}/mane_{MANE_VERSION}.json"
 DESTINATION_SUMMARY="${DESTINATION}/${LOCAL_SUMMARY_NAME}"
 

--- a/reference_generating_scripts/mane_summary_manager.sh
+++ b/reference_generating_scripts/mane_summary_manager.sh
@@ -14,7 +14,7 @@ python3 reference_generating_scripts/mane_summary_parser.py \
     --format json
 
 # destination for the output
-MAIN_OR_TEST=${1:-"main"}
+MAIN_OR_TEST=${2:-"main"}
 
 # copy all the content to GCP - keep the same file names, copy in bulk
 DESTINATION="gs://cpg-common-${MAIN_OR_TEST}/references/mane_${ENSEMBL_VERSION}"

--- a/reference_generating_scripts/mane_summary_parser.py
+++ b/reference_generating_scripts/mane_summary_parser.py
@@ -52,7 +52,10 @@ def mane_to_ht(input_path: str, output_path: str):
     temp_tsv = 'temp.tsv'
     # read the file
     with gzip.open(input_path, 'rt') as handle, open(temp_tsv, 'wt') as write_handle:
-        write_handle.write('\t'.join(['enst', 'ensg', 'ensp', 'symbol', 'mane_id', 'mane_status']) + '\n')
+        write_handle.write(
+            '\t'.join(['enst', 'ensg', 'ensp', 'symbol', 'mane_id', 'mane_status'])
+            + '\n'
+        )
         reader = DictReader(handle, delimiter='\t')
         for line in reader:
             line_elements = [

--- a/reference_generating_scripts/mane_summary_parser.py
+++ b/reference_generating_scripts/mane_summary_parser.py
@@ -1,0 +1,96 @@
+#!/usr/bin/env python3
+
+"""
+Reformat the MANE summary file into a Hail Table
+https://ftp.ncbi.nlm.nih.gov/refseq/MANE/README.txt
+"""
+
+import gzip
+import json
+from argparse import ArgumentParser
+from collections import defaultdict
+from csv import DictReader
+
+import hail as hl
+
+
+def mane_to_json(input_path: str, output_path: str):
+    """
+    Reformat the MANE summary file into a JSON file
+    I can't quite grok the annotation from table, so I'm doing the dumb version
+    """
+    transcript_dict: dict[str, dict[str, str]] = defaultdict(dict)
+
+    with gzip.open(input_path, 'rt') as handle:
+        reader = DictReader(handle, delimiter='\t')
+        for line in reader:
+
+            enst = line['Ensembl_nuc'].split('.')[0]
+            ensg = line['Ensembl_Gene'].split('.')[0]
+            ensp = line['Ensembl_prot'].split('.')[0]
+            symbol = line['symbol'].split('.')[0]
+            mane_id = line['RefSeq_nuc'].split('.')[0]
+            mane_status = line['MANE_status']
+
+            transcript_dict[enst] = {
+                'mane_status': mane_status,
+                'ensp': ensp,
+                'mane_id': mane_id,
+                'ensg': ensg,
+                'symbol': symbol,
+            }
+
+    with open(output_path, 'w') as handle:
+        json.dump(transcript_dict, handle, indent=2)
+
+
+def mane_to_ht(input_path: str, output_path: str):
+    """
+    Reformat the MANE summary file into a Hail Table
+    """
+
+    temp_tsv = 'temp.tsv'
+    # read the file
+    with gzip.open(input_path, 'rt') as handle, open(temp_tsv, 'wt') as write_handle:
+        write_handle.write('\t'.join(['enst', 'ensg', 'ensp', 'symbol', 'mane_id', 'mane_status']) + '\n')
+        reader = DictReader(handle, delimiter='\t')
+        for line in reader:
+            line_elements = [
+                line['Ensembl_nuc'].split('.')[0],  # ENST
+                line['Ensembl_Gene'].split('.')[0],  # ENSG
+                line['Ensembl_prot'].split('.')[0],  # ENSP
+                line['symbol'].split('.')[0],  # symbol
+                line['RefSeq_nuc'].split('.')[0],  # NMID
+                line['MANE_status'],  # "MANE Select" or "MANE Plus Clinical"
+            ]
+            write_handle.write('\t'.join(line_elements) + '\n')
+
+    # import as a hail table, force=True as this isn't Block-Zipped so all read on one core
+    # No data types provided, all string columns
+    ht = hl.import_table(temp_tsv, force=True)
+    ht = ht.key_by('enst')
+    ht.write(output_path, overwrite=True)
+    ht.describe()
+    ht.show()
+
+
+def cli_main():
+
+    parser = ArgumentParser()
+    parser.add_argument('--input', help='Path to the MANE summary file')
+    parser.add_argument('--output', help='Path to write the resulting HT')
+    parser.add_argument('--format', choices=['json', 'ht'], default='json')
+    args = parser.parse_args()
+
+    hl.context.init_spark(master='local[4]', default_reference='GRCh38', quiet=True)
+
+    if args.format == 'json':
+        mane_to_json(input_path=args.input, output_path=args.output)
+    elif args.format == 'ht':
+        mane_to_ht(input_path=args.input, output_path=args.output)
+    else:
+        raise ValueError(f'Unrecognised format {args.format}')
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/references.py
+++ b/references.py
@@ -478,4 +478,24 @@ SOURCES = [
         dst='gnomad/v4.1/ht/gnomad.genomes.v4.1.sites.ht',
         transfer_cmd=gcs_rsync,
     ),
+    Source(
+        'alphamissense',
+        # alphamissense raw data, processed HT, and compressed HT
+        dst='alphamissense',
+        files=dict(
+            raw_tsv='alphamissense_38.tsv.gz',
+            ht='alphamissense_38.ht',
+            ht_tar='alphamissense_38.ht.tar.gz',
+        ),
+    ),
+    Source(
+        'ensembl_113',
+        # ensembl GFF3, and derived BED files
+        dst='ensembl_113',
+        files=dict(
+            gff3='GRCh38.gff3.gz',
+            bed='GRCh38.bed',
+            hmerged_bedt_tar='merged_GRCh38.bed',
+        ),
+    ),
 ]

--- a/references.py
+++ b/references.py
@@ -494,8 +494,8 @@ SOURCES = [
         dst='ensembl_113',
         files=dict(
             gff3='GRCh38.gff3.gz',
-            bed='GRCh38.bed',
-            hmerged_bedt_tar='merged_GRCh38.bed',
+            bed='GRCh38.bed',  # contains a column with each Gene's name/ID
+            merged_bed='merged_GRCh38.bed',  # simplified regions, lacks per-gene data
         ),
     ),
     Source(
@@ -503,8 +503,8 @@ SOURCES = [
         # MANE v.1.4 digest and raw data
         dst='mane_1.4',
         files=dict(
-            summary='mane_1.4.summary.txt.gz',
-            json='mane_1.4.json',
+            summary='mane_1.4.summary.txt.gz',  # raw data from MANE
+            json='mane_1.4.json',  # parsed into a per-transcript lookup
         ),
     ),
 ]

--- a/references.py
+++ b/references.py
@@ -498,4 +498,13 @@ SOURCES = [
             hmerged_bedt_tar='merged_GRCh38.bed',
         ),
     ),
+    Source(
+        'mane_1.4',
+        # MANE v.1.4 digest and raw data
+        dst='mane_1.4',
+        files=dict(
+            summary='mane_1.4.summary.txt.gz',
+            json='mane_1.4.json',
+        ),
+    ),
 ]


### PR DESCRIPTION
Pulls the Ensembl GFF3 file, generates 2 BEDs file from it
- one region per gene, each region having the names/IDs of the relevant genes. 
- a version with merged overlapping regions, to present fewer overall lines for region filtering

Pulls the MANE summary data
- stores the MANE summary raw data
- stores a dictionary-format representation of the contained data

The Mane and Ensembl processes are multi-step, mediated by a bash script
- the bash script is run through Analysis-Runner
- the bash script localises the input files using wget
- bash script calls the python script to process the data
- bash script uploads the resulting files to GCP via the `gcloud sdk`

Both scripts are parametrised to an Ensembl/MANE version, in terms of input and output path. These processes are pulled out of the proposed talos reannotation workflow where I previously had them as Stages

Adds the locations these scripts would generate to the default references template. If they're run with alternative inputs you won't need new scripts, but would need to add sections to the config file.

Correction to the Echtvar output config entry

---

Adds additional functionality to the Echtvar script - a user can add a BED file (e.g. the ensembl genic-regions file generated by the new workflow added here). This results in a reduced Echtvar output, with each contig being region filtered prior to being encoded.

The name of the BED file used is incorporated into the output file path