### PR TITLE
Adds gnomAD genomes + exomes joint data

### DIFF
--- a/references.py
+++ b/references.py
@@ -30,6 +30,19 @@ def gcs_rsync(src: str, dst: str, project: str) -> str:
     return quote_command(c)
 
 
+def gcs_rsync_no_billing_project(src: str, dst: str, project: str) -> str:
+    """
+    defines a gcs rsync function, without setting the billing project
+    within CI the billing project attempts to reset after ~60 mins, killing transfers
+    only use this with public (i.e. not requester-pays) buckets
+    -r for recursive
+    """
+    print(f'ignoring {project} - attempting standard transfer')
+    assert src.startswith('gs://')
+    c = ['gcloud', 'storage', 'rsync', '-r', src, dst]
+    return quote_command(c)
+
+
 def gcs_cp_single(src: str, dst: str, project: str) -> str:
     """
     defines a single-file gcs copy function
@@ -477,6 +490,19 @@ SOURCES = [
         src='gs://gcp-public-data--gnomad/release/4.1/ht/genomes/gnomad.genomes.v4.1.sites.ht',
         dst='gnomad/v4.1/ht/gnomad.genomes.v4.1.sites.ht',
         transfer_cmd=gcs_rsync,
+    ),
+    Source(
+        'gnomad_4.1_joint_vcfs',
+        src='gs://gcp-public-data--gnomad/release/4.1/vcf/joint',
+        dst='gnomad/v4.1/joint/vcfs',
+        files={contig: f'gnomad.joint.v4.1.sites.{contig}.vcf.bgz' for contig in CANONICAL_CHROMOSOMES},
+        transfer_cmd=gcs_rsync_no_billing_project,
+    ),
+    Source(
+        'gnomad_4.1_joint_ht',
+        src='gs://gcp-public-data--gnomad/release/4.1/ht/joint/gnomad.joint.v4.1.sites.ht',
+        dst='gnomad/v4.1/joint/ht/gnomad.joint.v4.1.sites.ht',
+        transfer_cmd=gcs_rsync_no_billing_project,
     ),
     Source(
         'alphamissense',


### PR DESCRIPTION
I was a little hasty with my initial pull of the references data over to our infrastructure... The data which was previously copied across is gnomAD v4.1 Genomes-only, which as I understand it is effectively gnomAD v3.

https://github.com/populationgenomics/references/blob/main/references.py#L460-L479

This PR adds an additional section for (and triggers the transfer of) the gnomAD v4.1 **joint Exome & Genome** data, in VCF and HT formats.

For long term storage costs/simplicity of the resulting config entries, I think deleting the v4.1 Genome data which was already transferred, and having the gnomAD v4.1 genome and exome superset **as gnomAD 4.1** internally might be better than adding this data to what we already hold...

The 4.1-Genomes data has AC/AN/AF etc., whilst this dataset holds counts, frequencies, QC and filtering allele frequencies for genome, exome, and joint, making our currently transferred data ~redundant. 

No production work is currently using 4.1, so if we want to delete what we have and start over, now would be the time 👀 