### PR TITLE
Fix bed merging script

### DIFF
--- a/reference_generating_scripts/generate_bed_from_ensembl.py
+++ b/reference_generating_scripts/generate_bed_from_ensembl.py
@@ -73,7 +73,7 @@ def generate_bed_lines(
             if (
                 line_as_list[TYPE_INDEX] not in TYPES_TO_KEEP
                 or 'ensembl' not in line_as_list[RESOURCE_INDEX]
-                or line_as_list[CHROM_INDEX] not in CANONICAL_CONTIGS
+                or f'chr{line_as_list[CHROM_INDEX]}' not in CANONICAL_CONTIGS
             ):
                 continue
 

--- a/references.py
+++ b/references.py
@@ -522,6 +522,9 @@ SOURCES = [
             gff3='GRCh38.gff3.gz',
             bed='GRCh38.bed',  # contains a column with each Gene's name/ID
             merged_bed='merged_GRCh38.bed',  # simplified regions, lacks per-gene data
+            # copeid from https://ftp.ensembl.org/pub/release-113/fasta/homo_sapiens/dna/Homo_sapiens.GRCh38.dna.primary_assembly.fa.gz
+            # decompressed locally and uploaded to GCP
+            unmasked_reference='Homo_sapiens.GRCh38.dna.primary_assembly.fa'
         ),
     ),
     Source(


### PR DESCRIPTION
A couple of quick tweaks 

- removes weird contigs from the BED files being generated. These are _usable_ by telling Hail to skip over them, but other tools may fail instead
- when merging overlapping regions this ensures we take the greatest possible area (inclusive of both start and end points). The merge I previously implemented was rubbish, graphically:

```txt
merge two regions:
|-------------------|
       |-------|
desired:
|-------------------|
actual:
|--------------|
```
- adds a config entry for the unmasked reference genome, required to annotate ClinVar with BCFtools