### PR TITLE
Add merged mackenzie exomes bed

### DIFF
--- a/references.py
+++ b/references.py
@@ -620,8 +620,8 @@ SOURCES = [
             idt_xgen_exome_research_panel_v1_target_regions_interval_list='xgen-exome-research-panel-targets-hg38.interval_list',
             idt_xgen_exome_research_panel_v1_probes_bed='xgen-exome-research-panel-probes-hg38.bed',
             idt_xgen_exome_research_panel_v1_probes_interval_list='xgen-exome-research-panel-probes-hg38.interval_list',
-            mackenzie_merged_exome_probes_bed='mackenzie_merged_exome_regions.bed',
-            mackenzie_merged_exome_probes_interval_list='mackenzie_merged_exome_regions.interval_list',
+            mackenzie_intersect_exome_probes_bed='mackenzie_intersect_exome_regions.bed',
+            mackenzie_intersect_exome_probes_interval_list='mackenzie_intersect_exome_regions.interval_list',
             ),
     ),
 ]

--- a/references.py
+++ b/references.py
@@ -620,6 +620,8 @@ SOURCES = [
             idt_xgen_exome_research_panel_v1_target_regions_interval_list='xgen-exome-research-panel-targets-hg38.interval_list',
             idt_xgen_exome_research_panel_v1_probes_bed='xgen-exome-research-panel-probes-hg38.bed',
             idt_xgen_exome_research_panel_v1_probes_interval_list='xgen-exome-research-panel-probes-hg38.interval_list',
+            mackenzie_merged_exome_probes_bed='mackenzie_merged_exome_regions.bed',
+            mackenzie_merged_exome_probes_interval_list='mackenzie_merged_exome_regions.interval_list',
             ),
     ),
 ]


### PR DESCRIPTION
this adds the mackenzie mission intersect exome probeset to the `references.py`

It was copied from `gs://cpg-mackenzie-test/exome/large_cohort/exome-region-intersection-1/twist_refseq_exome_panel_target_regions_bed-agilent_sureselect_clinical_research_exome_v2_target_regions_bed/exome_regions.bed`

to "gs://cpg-common-test/references/exome-probesets/hg38/mackenzie_intersect_exome_regions.bed"


and is the intersect of `twist_refseq_exome_panel_target_regions` and `agilent_sureselect_clinical_research_exome_v2_target_regions` which were the two exome probesets used in Mackenzies.