### PR TITLE
added the exome def files for the union of mackenzie-exomes

### DIFF
--- a/references.py
+++ b/references.py
@@ -622,6 +622,8 @@ SOURCES = [
             idt_xgen_exome_research_panel_v1_probes_interval_list='xgen-exome-research-panel-probes-hg38.interval_list',
             mackenzie_intersect_exome_probes_bed='mackenzie_intersect_exome_regions.bed',
             mackenzie_intersect_exome_probes_interval_list='mackenzie_intersect_exome_regions.interval_list',
+            mackenzie_union_exome_probes_bed='mackenzie_union_exome_regions.bed',
+            mackenzie_union_exome_probes_interval_list='mackenzie_union_exome_regions.interval_list'
             ),
     ),
 ]


### PR DESCRIPTION
This adds the union of mackenzie mission exomes to `references.py` -> bed and picard intervals
the `union.bed` is then uploaded: 
`gcloud storage cp union.bed gs://cpg-common-test/references/exome-probesets/hg38/mackenzie_union_exome_regions.bed`

Then once PR is accepted we launch this job (which has the side effect of copying the bedfile from `test` to `main`):

```
analysis-runner \
--dataset common \
--access-level full \
--description  'copying union of mackenzie exomes to references' \
--output-dir "" \
references/exome_designs/convert_bedfiles_to_interval_lists.py
```