### PR TITLE
Update transcript annotation resources

### DIFF
--- a/references.py
+++ b/references.py
@@ -276,6 +276,20 @@ SOURCES = [
         transfer_cmd=gcs_cp_single,
     ),
     Source(
+        'gencode_v44',
+        # Reference data related to the OurDNA browser
+        src='https://ftp.ebi.ac.uk/pub/databases/gencode/Gencode_human/release_44/gencode.v44.annotation.gtf.gz',
+        dst='ourdna_browser/v0/gencode.v44.annotation.gtf.gz',
+        transfer_cmd=curl,
+    ),
+    Source(
+        'mane_select_v1.4',
+        # Reference data related to the OurDNA browser
+        srs='https://ftp.ncbi.nlm.nih.gov/refseq/MANE/MANE_human/release_1.4/MANE.GRCh38.v1.4.summary.txt.gz',
+        dst='ourdna_browser/v0/MANE.GRCh38.v1.4.summary.txt.gz',
+        transfer_cmd=curl,
+    ),
+    Source(
         'seqr_combined_reference_data',
         # The Broad resources for annotation for the Seqr Loader
         src='gs://seqr-reference-data/GRCh38/all_reference_data/combined_reference_data_grch38.ht',


### PR DESCRIPTION
We noticed that in our latest test of loading browser data, we have more transcripts than gnomAD v4 does. This is most likely due to different versions of VEP being used.

gnomAD v4 currently uses Gencode v39 and MANE v0.95. This is okay but they also use VEP 95 (I think, bit hard to tell from their code).

Adding Gencode v44 and MANE v1.4 to our resources so that they can be used in our pipeline because we are using VEP 110.

