### PR TITLE
Add alphagenome feather file

### DIFF
--- a/references.py
+++ b/references.py
@@ -688,4 +688,11 @@ SOURCES = [
             mackenzie_union_exome_probes_interval_list='mackenzie_union_exome_regions.interval_list'
             ),
     ),
+    Source(
+        # Alphagenome reference file(s)
+        'alphagenome_feather',
+        src='https://storage.googleapis.com/alphagenome/reference/gencode/hg38/gencode.v46.annotation.gtf.gz.feather',
+        dst='alphagenome/gencode.v46.annotation.gtf.gz.feather',
+        transfer_cmd=curl,
+    ),
 ]


### PR DESCRIPTION
Copies the alphagenome feather file into our local (Aus-region) GCP storage, and adds to our global references config file.

This will appear in the standard analysis-runner config templatw TOML as

```
[references]
...
alphagenome_feather = 'gs://cpg-common-main/references/alphagenome/gencode.v46.annotation.gtf.gz.feather'
```