### PR TITLE
Add Mitochondrial regions into the BED files and GFF3

### DIFF
--- a/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
+++ b/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
@@ -5,6 +5,7 @@
 # first identify the location of the ensembl GFF3 based on its version
 ENSEMBL_VERSION=${1:-"113"}
 GFF3_URL="https://ftp.ensembl.org/pub/release-${ENSEMBL_VERSION}/gff3/homo_sapiens/Homo_sapiens.GRCh38.${ENSEMBL_VERSION}.gff3.gz"
+INITIAL_OUTPUT_GFF3="initial_GRCh38.gff3.gz"
 LOCAL_OUTPUT_GFF3="GRCh38.gff3.gz"
 LOCAL_OUTPUT_BED="GRCh38.bed"
 MERGED_OUTPUT_BED="merged_GRCh38.bed"
@@ -13,7 +14,9 @@ MERGED_OUTPUT_BED="merged_GRCh38.bed"
 MAIN_OR_TEST=${2:-"main"}
 
 # get that
-wget "${GFF3_URL}" -O "${LOCAL_OUTPUT_GFF3}"
+wget "${GFF3_URL}" -O "${INITIAL_OUTPUT_GFF3}"
+
+zcat "${INITIAL_OUTPUT_GFF3}" | sed 's/^MT/M/' | gzip > ${LOCAL_OUTPUT_GFF3}
 
 # parse that gff3 into a BED file
 python3 reference_generating_scripts/generate_bed_from_ensembl.py \

--- a/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
+++ b/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
@@ -6,7 +6,7 @@
 ENSEMBL_VERSION=${1:-"115"}
 GFF3_URL="https://ftp.ensembl.org/pub/release-${ENSEMBL_VERSION}/gff3/homo_sapiens/Homo_sapiens.GRCh38.${ENSEMBL_VERSION}.gff3.gz"
 INITIAL_OUTPUT_GFF3="initial_GRCh38.gff3.gz"
-LOCAL_OUTPUT_GFF3="GRCh38.gff3.gz"
+LOCAL_OUTPUT_GFF3="GRCh38_chrM_renamed.gff3.gz"
 LOCAL_OUTPUT_BED="GRCh38.bed"
 MERGED_OUTPUT_BED="merged_GRCh38.bed"
 

--- a/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
+++ b/reference_generating_scripts/generate_bed_from_ensembl_manager.sh
@@ -3,7 +3,7 @@
 # This script is used to manage the generation of a BED file from the ensembl GFF3
 
 # first identify the location of the ensembl GFF3 based on its version
-ENSEMBL_VERSION=${1:-"113"}
+ENSEMBL_VERSION=${1:-"115"}
 GFF3_URL="https://ftp.ensembl.org/pub/release-${ENSEMBL_VERSION}/gff3/homo_sapiens/Homo_sapiens.GRCh38.${ENSEMBL_VERSION}.gff3.gz"
 INITIAL_OUTPUT_GFF3="initial_GRCh38.gff3.gz"
 LOCAL_OUTPUT_GFF3="GRCh38.gff3.gz"


### PR DESCRIPTION
Fun one 

- the GFF3 file from Ensembl is an unusual format, it's not trivial to reproduce a GFF3 file which bcftools will accept
- the default ensembl GFF3 file calls the mitochondrial contig  "MT", and has no "chr" prefix
- Hail requires the mitochondrial contig to be called "M", otherwise it crashes and ruins everyones day
- The Fasta file we have from the Broad also settles on M, but prefixed as "chrM"


So... we can download the GFF3 from ensembl, pipe through sed to replace the `^MT` with just `M`. This gives us Hail-compatible contigs for annotation.

We can then use this new file in a bcftools csq call:

```
bcftools csq \
    -f Homo_sapiens_assembly38.chrM.fasta \
    --local-csq \
    -g chrM_adjusted_Homo_sapiens.GRCh38.115.gff3.gz \
    -o OUTPUT.vcf.gz \
    --unify-chr-names 'chr,-,chr' \
    INPUT.vcf.bg
```

Where `--unify-chr-names  'chr,-,chr'` is trimming the `chr` prefix from the vcf and Fasta to make everything compatible