### PR TITLE
Per-design exome beds for Mackenzie (Twist VCGS, Agilent CRE v1)

### DIFF
--- a/exome_designs/README.md
+++ b/exome_designs/README.md
@@ -27,7 +27,15 @@ Note that the bed files need to bed converted with `picard` to 'interval_list' f
 using `../reference_generating_scripts/convert_bed_to_interval_list.py` or some modification of that script.
 
 ## Transfer exome probesets to `gs://cpg-common-test`
-gcloud storage cp *.bed gs://cpg-common-test/references/exome-probesets/hg38/ 
+
+hg38 BEDs (default UCSC output, plus the Twist VCGS custom BED below):
+
+gcloud storage cp *_hg38.bed gs://cpg-common-test/references/exome-probesets/hg38/
+
+hg19 BEDs (intermediate inputs to the liftover job — currently only the Agilent
+CRE v1 files below):
+
+gcloud storage cp *_hg19.bed gs://cpg-common-test/references/exome-probesets/hg19/
 
 ## Run interval_conversion on main
 
@@ -40,3 +48,72 @@ analysis-runner \
     convert_bedfiles_to_interval_lists.py
 
 ```
+
+## Twist VCGS custom
+
+Fetches Twist Comprehensive Exome + VCGS custom content (hg38) — the design used
+for Mackenzie's Twist cohort. Output goes alongside the script; upload to
+`cpg-common-test` afterwards.
+
+```
+bash get_twist_vcgs_custom.sh
+gcloud storage cp Twist_VCGS_Exome_Covered_Targets_hg38.bed \
+    gs://cpg-common-test/references/exome-probesets/hg38/
+```
+
+The matching hg38 `interval_list` is produced by the standard
+`convert_bedfiles_to_interval_lists.py` AR invocation above.
+
+## Agilent CRE v1 (hg19 → hg38 liftover)
+
+Agilent SureSelect Clinical Research Exome v1 (design id `S06588914`) is only
+distributed by UCSC at hg19, so a manual liftover step is required before the
+hg38 BEDs land in references.
+
+### 1. Download hg19 BEDs
+
+```
+python download_hg19_agilent_cre_v1.py
+gcloud storage cp Agilent_ClinicalResearchExome_v1_*_hg19.bed \
+    gs://cpg-common-test/references/exome-probesets/hg19/
+```
+
+### 2. Bootstrap hg19 sequence dictionary (one-time)
+
+Once `hg19.fa.gz` has been transferred by CI (via the `hg19_fasta` Source in
+`references.py`), generate the matching picard `.dict` alongside it. The job is
+idempotent: it no-ops if `hg19.dict` is already present.
+
+```
+analysis-runner \
+    --dataset common \
+    --access-level full \
+    --description  'Bootstrap hg19 picard sequence dictionary' \
+    --output-dir cpg-common-main/references \
+    generate_hg19_dict.py
+```
+
+### 3. Liftover + convert
+
+Chains `picard BedToIntervalList → LiftOverIntervalList → IntervalListToBed` per
+`*_hg19.bed` in `cpg-common-test`, writes the hg38 BED + interval_list to the
+paths declared in `references.py` under `exome_probesets`, and logs the count of
+rejected intervals so the operator can sanity-check liftover loss before
+promoting the BEDs.
+
+```
+analysis-runner \
+    --dataset common \
+    --access-level full \
+    --description  'liftover hg19 exome beds to hg38' \
+    --output-dir cpg-common-main/references \
+    liftover_and_convert_hg19_bedfiles.py
+```
+
+### Sanity-check post-liftover
+
+Agilent's portal ships hg38 directly. Compare interval counts and total bp of
+the lifted `_hg38.bed` outputs against the portal baseline at
+`/Users/jossch/Downloads/S06588914/S06588914_{Regions,Covered}.bed` before
+promoting the BEDs into ICA. Those files are not the source of truth — only a
+reference for diffing.

--- a/exome_designs/download_hg19_agilent_cre_v1.py
+++ b/exome_designs/download_hg19_agilent_cre_v1.py
@@ -1,0 +1,125 @@
+#!/usr/bin/env python3
+
+"""
+Download Agilent SureSelect Clinical Research Exome v1 (S06588914) probeset
+BED files from UCSC at hg19 coordinates. Outputs two files in the current
+directory:
+
+  - Agilent_ClinicalResearchExome_v1_Regions_hg19.bed
+  - Agilent_ClinicalResearchExome_v1_Covered_hg19.bed
+
+These hg19 BEDs are intermediate artifacts: upload them to cpg-common-test
+and then lift over to hg38 with liftover_and_convert_hg19_bedfiles.py.
+
+Manufacturer-portal baseline for sanity-check comparison post-liftover:
+    /Users/jossch/Downloads/S06588914/S06588914_Regions.bed
+    /Users/jossch/Downloads/S06588914/S06588914_Covered.bed
+Agilent's portal ships hg38 directly; those files are not the source here,
+only a reference for interval-count / total-bp diffs after liftover.
+"""
+
+import urllib.parse as up
+from pathlib import Path
+
+import bbi
+import polars as pl
+import requests
+
+API_URL = 'https://api.genome.ucsc.edu'
+DL_URL = 'https://hgdownload.soe.ucsc.edu'
+TRACK_ENDPOINT = '/list/tracks'
+GENOME = 'hg19'
+CANONICAL_CHRS = [f'chr{x}' for x in list(range(1, 23)) + ['X', 'Y', 'M']]
+TARGET_DESIGN_ID = 'S06588914'
+OUTPUT_FILENAMES = {
+    'regions': 'Agilent_ClinicalResearchExome_v1_Regions_hg19.bed',
+    'covered': 'Agilent_ClinicalResearchExome_v1_Covered_hg19.bed',
+}
+
+
+def get_exome_probesets(
+    api_url: str, track_endpoint: str, genome: str,
+) -> dict[str, dict]:
+    """
+    Fetch the UCSC ``exomeProbesets`` super-track listing for ``genome``.
+    Returns the raw dict keyed by track name; values carry ``shortLabel``,
+    ``longLabel`` and ``bigDataUrl`` among other fields.
+    """
+
+    params = {'genome': genome}
+    response = requests.get(up.urljoin(api_url, track_endpoint), params)
+    return response.json()[genome]['exomeProbesets']
+
+
+def find_design_tracks(
+    probesets: dict[str, dict], design_id: str,
+) -> dict[str, str]:
+    """
+    Locate the Regions and Covered BigBed URLs for the given Agilent design id
+    (e.g. ``S06588914``) within the UCSC exomeProbesets track listing. Matches
+    by BigBed filename stem (``<design>_Regions`` / ``<design>_Covered``) and
+    cross-checks the track ``shortLabel`` for the design id.
+    """
+
+    matches: dict[str, str] = {}
+    for track in probesets.values():
+        url = track.get('bigDataUrl', '')
+        if not url:
+            continue
+        stem = Path(url).stem
+        in_url = design_id in stem
+        in_label = design_id in track.get('shortLabel', '')
+        if not (in_url or in_label):
+            continue
+        if stem.endswith('_Regions'):
+            matches['regions'] = url
+        elif stem.endswith('_Covered'):
+            matches['covered'] = url
+    missing = {'regions', 'covered'} - matches.keys()
+    if missing:
+        raise RuntimeError(
+            f'Could not locate {design_id} hg19 entries for: {sorted(missing)}',
+        )
+    return matches
+
+
+def write_bed_from_bigbed(
+    big_data_url: str, dl_url: str, output_path: Path,
+    canonical_chrs: list[str],
+) -> None:
+    """
+    Stream the BigBed at ``big_data_url`` (relative to ``dl_url``), keep only
+    ``canonical_chrs``, and write to ``output_path`` as 3-column BED.
+    """
+
+    track = bbi.open(up.urljoin(dl_url, big_data_url))
+    bed_df = pl.DataFrame(
+        schema={'chrom': pl.String, 'start': pl.Int64, 'end': pl.Int64},
+    )
+    for chrom, size in track.chromsizes.items():
+        if chrom not in canonical_chrs:
+            continue
+        chrom_bed = pl.from_pandas(
+            track.fetch_intervals(chrom=chrom, start=1, end=size)[
+                ['chrom', 'start', 'end']
+            ],
+        )
+        bed_df = pl.concat([bed_df, chrom_bed])
+    bed_df.write_csv(file=output_path, include_header=False, separator='\t')
+
+
+def main() -> None:
+    """
+    Download Regions + Covered hg19 BEDs for Agilent CRE v1 (S06588914).
+    """
+
+    probesets = get_exome_probesets(API_URL, TRACK_ENDPOINT, GENOME)
+    urls = find_design_tracks(probesets, TARGET_DESIGN_ID)
+    for kind, filename in OUTPUT_FILENAMES.items():
+        write_bed_from_bigbed(
+            urls[kind], DL_URL, Path(filename), CANONICAL_CHRS,
+        )
+
+
+if __name__ == '__main__':
+    main()

--- a/exome_designs/generate_hg19_dict.py
+++ b/exome_designs/generate_hg19_dict.py
@@ -1,0 +1,70 @@
+#!/usr/bin/env python3
+
+"""
+One-shot bootstrap that generates hg19.dict alongside the hg19 fasta in
+gs://cpg-common-main/references/hg19/v0/. The dict is consumed by
+LiftOverIntervalList inside liftover_and_convert_hg19_bedfiles.py.
+
+analysis-runner \
+    --dataset common \
+    --access-level full \
+    --description  'Bootstrap hg19 picard sequence dictionary' \
+    --output-dir cpg-common-main/references \
+    generate_hg19_dict.py
+
+NOTES:
+1. Run in MAIN (hg19.dict lives in cpg-common-main).
+2. Requires hg19.fa.gz to have been transferred by CI via the `hg19_fasta`
+   Source in references.py.
+3. Idempotent: exits without submitting a batch if hg19.dict is already
+   present at reference_path('hg19_dict').
+"""
+
+import sys
+
+from cloudpathlib import AnyPath
+from cpg_utils.config import reference_path
+from cpg_utils.hail_batch import get_batch, image_path
+
+
+def main() -> None:
+    """
+    Submit a single picard CreateSequenceDictionary job to produce hg19.dict
+    next to hg19.fa.gz in references.
+    """
+
+    fasta_path = reference_path('hg19_fasta')
+    dict_path = reference_path('hg19_dict')
+
+    if AnyPath(dict_path).exists():
+        print(f'hg19 dict already present at {dict_path}; nothing to do.')
+        return
+
+    if not AnyPath(fasta_path).exists():
+        sys.exit(
+            f'hg19 fasta not found at {fasta_path}. Run CI on the references '
+            f'repo to transfer hg19.fa.gz before generating the dict.',
+        )
+
+    b = get_batch()
+    fasta_input = b.read_input(fasta_path)
+
+    picard_job = b.new_job(name='Generate hg19 sequence dictionary')
+    picard_job.image(image_path('picard'))
+    picard_job.storage('20Gi')
+
+    picard_job.command(
+        f"""
+        gunzip -c {fasta_input} > $BATCH_TMPDIR/hg19.fa
+        picard CreateSequenceDictionary \
+            R=$BATCH_TMPDIR/hg19.fa \
+            O={picard_job.ofile}
+        """,
+    )
+
+    b.write_output(picard_job.ofile, dict_path)
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/exome_designs/get_twist_vcgs_custom.sh
+++ b/exome_designs/get_twist_vcgs_custom.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+# Fetch the Twist Comprehensive Exome + VCGS custom content target bed (hg38).
+# Output goes alongside this script; upload to cpg-common-test afterwards.
+set -euo pipefail
+URL='https://www.twistbioscience.com/content/dam/twistbioscience/resources/2021-10/VCGS_Exome_Covered_Targets_hg38%2040.1MB%20.bed'
+curl -L "$URL" -o Twist_VCGS_Exome_Covered_Targets_hg38.bed

--- a/exome_designs/liftover_and_convert_hg19_bedfiles.py
+++ b/exome_designs/liftover_and_convert_hg19_bedfiles.py
@@ -1,0 +1,182 @@
+#!/usr/bin/env python3
+
+"""
+This script lifts over hg19 exome BED files to hg38 with picard
+LiftOverIntervalList, and copies the resulting BED and interval_list files
+to cpg-common-main references.
+
+analysis-runner \
+    --dataset common \
+    --access-level full \
+    --description  'liftover hg19 exome beds to hg38' \
+    --output-dir cpg-common-main/references \
+    liftover_and_convert_hg19_bedfiles.py
+
+
+NOTES:
+1. Run in MAIN!
+2. Assumes hg19 bedfiles are in TEST, alongside the existing hg38 ones:
+   gs://cpg-common-test/references/exome-probesets/hg38/*_hg19.bed
+3. Requires hg19_dict to be present in references (run generate_hg19_dict.py
+   once before this script).
+4. Per-file pipeline:
+     picard BedToIntervalList    (hg19 BED -> hg19 interval_list, SD=hg19_dict)
+     picard LiftOverIntervalList (hg19 -> hg38 interval_list, target SD=broad)
+     picard IntervalListToBed    (hg38 interval_list -> hg38 BED)
+5. Both the BED and interval_list output filenames (with _hg19 substituted for
+   _hg38) must exist in references.py under the exome_probesets Source.
+6. Logs the count of rejected intervals from picard LiftOverIntervalList so
+   the operator can sanity-check liftover loss before merging into ICA.
+"""
+
+import os
+import sys
+from collections.abc import Generator, Iterator
+from pathlib import Path
+
+import click
+from cloudpathlib import AnyPath, CloudPath
+from cpg_utils.config import ConfigError, config_retrieve, cpg_test_dataset_path, reference_path
+from cpg_utils.hail_batch import get_batch, image_path
+
+SOURCE = 'exome_probesets'
+
+
+def get_hg19_bedfile_paths(exome_path: str) -> Iterator[Path] | Generator[CloudPath, None, None]:
+    """
+    Returns a generator of CloudPath for hg19 bed files (``*_hg19.bed``)
+    found at ``exome_path`` in cpg-common-test/references.
+    """
+
+    bed_path = AnyPath(cpg_test_dataset_path(exome_path))
+    return bed_path.rglob('*_hg19.bed')
+
+
+def liftover_hg19_bedfiles(
+    bedfile_paths: Iterator[Path] | Generator[CloudPath, None, None],
+    hg38_sd_ref: str,
+    chain_ref: str,
+    hg19_dict_ref: str,
+    exome_ref_dict: dict[str, str],
+) -> None:
+    """
+    For each ``*_hg19.bed`` in cpg-common-test, run a single picard job that
+    chains BedToIntervalList -> LiftOverIntervalList -> IntervalListToBed and
+    writes the resulting hg38 BED and interval_list to cpg-common-main at the
+    paths declared by references.py.
+    """
+
+    b = get_batch()
+    hg38_sd_input = b.read_input(reference_path(hg38_sd_ref))
+    hg19_dict_input = b.read_input(reference_path(hg19_dict_ref))
+    chain_input = b.read_input(reference_path(chain_ref))
+
+    for bed_path in bedfile_paths:
+        hg19_bed_file = bed_path.parts[-1]
+        hg38_bed_file = hg19_bed_file.replace('_hg19.bed', '_hg38.bed')
+        hg38_interval_list_file = hg19_bed_file.replace('_hg19.bed', '_hg38.interval_list')
+
+        try:
+            bed_out_key = exome_ref_dict[hg38_bed_file]
+            interval_out_key = exome_ref_dict[hg38_interval_list_file]
+        except KeyError as missing:
+            sys.exit(
+                f'No reference entry for expected hg38 output {missing.args[0]} '
+                f'(derived from {hg19_bed_file}). Check references.py.',
+            )
+
+        bed_out_path = reference_path(f'{SOURCE}/{bed_out_key}')
+        interval_list_out_path = reference_path(f'{SOURCE}/{interval_out_key}')
+
+        picard_job = b.new_job(name=f'Liftover {hg19_bed_file} hg19 -> hg38')
+        picard_job.image(image_path('picard'))
+        picard_job.declare_resource_group(
+            hg38_outputs={
+                'bed': '{root}.bed',
+                'interval_list': '{root}.interval_list',
+            },
+        )
+
+        picard_job.command(
+            f"""
+            set -euo pipefail
+
+            picard BedToIntervalList \
+                I={b.read_input(str(bed_path))} \
+                O=$BATCH_TMPDIR/hg19.interval_list \
+                SD={hg19_dict_input}
+
+            picard LiftOverIntervalList \
+                I=$BATCH_TMPDIR/hg19.interval_list \
+                O=$BATCH_TMPDIR/hg38.interval_list \
+                SD={hg38_sd_input} \
+                CHAIN={chain_input} \
+                REJECT=$BATCH_TMPDIR/rejected.interval_list
+
+            rejected=$(grep -cv '^@' $BATCH_TMPDIR/rejected.interval_list || true)
+            echo "Liftover rejected intervals for {hg19_bed_file}: $rejected"
+
+            picard IntervalListToBed \
+                I=$BATCH_TMPDIR/hg38.interval_list \
+                O=$BATCH_TMPDIR/hg38.bed
+
+            cp $BATCH_TMPDIR/hg38.interval_list {picard_job.hg38_outputs.interval_list}
+            cp $BATCH_TMPDIR/hg38.bed {picard_job.hg38_outputs.bed}
+            """,
+        )
+
+        b.write_output(picard_job.hg38_outputs.bed, bed_out_path)
+        b.write_output(picard_job.hg38_outputs.interval_list, interval_list_out_path)
+
+    b.run(wait=False)
+
+
+@click.command()
+@click.option(
+    '--exome-path',
+    required=True,
+    help='String identifying PATH (in cpg-common-test) of the hg19 bed files.',
+    default='references/exome-probesets/hg38',
+)
+@click.option(
+    '--hg38-sd-ref',
+    required=True,
+    help='Reference key for the hg38 sequence dictionary used as liftover target SD.',
+    default='broad/genome_calling_interval_lists',
+)
+@click.option(
+    '--chain-ref',
+    required=True,
+    help='Reference key for the hg19 -> hg38 liftover chain.',
+    default='liftover_37_to_38',
+)
+@click.option(
+    '--hg19-dict-ref',
+    required=True,
+    help='Reference key for the hg19 picard sequence dictionary.',
+    default='hg19_dict',
+)
+def main(exome_path, hg38_sd_ref, chain_ref, hg19_dict_ref):
+    """
+    Lift over hg19 exome BED files in cpg-common-test to hg38 with picard,
+    and write hg38 BED + interval_list outputs to the paths declared in
+    references.py under exome_probesets.
+    """
+
+    bedfile_paths = get_hg19_bedfile_paths(exome_path)
+
+    # reverse map of actual_file_name -> reference subkey
+    try:
+        ref_exome_dict = config_retrieve(['references', SOURCE])
+    except ConfigError:
+        sys.exit(f'No reference entry for provided source: {SOURCE}')
+
+    exome_ref_dict = {os.path.basename(v): k for k, v in ref_exome_dict.items()}
+
+    liftover_hg19_bedfiles(
+        bedfile_paths, hg38_sd_ref, chain_ref, hg19_dict_ref, exome_ref_dict,
+    )
+
+
+if __name__ == '__main__':
+    main()

--- a/exome_designs/liftover_and_convert_hg19_bedfiles.py
+++ b/exome_designs/liftover_and_convert_hg19_bedfiles.py
@@ -15,8 +15,9 @@ analysis-runner \
 
 NOTES:
 1. Run in MAIN!
-2. Assumes hg19 bedfiles are in TEST, alongside the existing hg38 ones:
-   gs://cpg-common-test/references/exome-probesets/hg38/*_hg19.bed
+2. Assumes hg19 bedfiles are in TEST, in a dedicated hg19/ subfolder
+   alongside the existing hg38/ layout:
+   gs://cpg-common-test/references/exome-probesets/hg19/*_hg19.bed
 3. Requires hg19_dict to be present in references (run generate_hg19_dict.py
    once before this script).
 4. Per-file pipeline:
@@ -136,7 +137,7 @@ def liftover_hg19_bedfiles(
     '--exome-path',
     required=True,
     help='String identifying PATH (in cpg-common-test) of the hg19 bed files.',
-    default='references/exome-probesets/hg38',
+    default='references/exome-probesets/hg19',
 )
 @click.option(
     '--hg38-sd-ref',

--- a/references.py
+++ b/references.py
@@ -201,6 +201,21 @@ SOURCES = [
         ),
     ),
     Source(
+        'hg19_fasta',
+        # UCSC hg19 fasta, used to bootstrap a picard sequence dictionary for
+        # LiftOverIntervalList (hg19 → hg38). See exome_designs/README.md.
+        src='https://hgdownload.soe.ucsc.edu/goldenPath/hg19/bigZips/hg19.fa.gz',
+        dst='hg19/v0/hg19.fa.gz',
+        transfer_cmd=curl,
+    ),
+    Source(
+        'hg19_dict',
+        # Picard sequence dictionary matching hg19_fasta. Generated once by
+        # exome_designs/generate_hg19_dict.py after CI lands hg19.fa.gz; this
+        # Source declares the path without driving a transfer.
+        dst='hg19/v0/hg19.dict',
+    ),
+    Source(
         'gatk_sv',
         # The Broad resources for running the GATK-SV workflow
         src='gs://gatk-sv-resources-public/hg38/v0/sv-resources',

--- a/references.py
+++ b/references.py
@@ -677,7 +677,7 @@ SOURCES = [
         ),
     ),
     Source(
-        'exome_probesets',
+        'exome_probesets_hg38',
         # exome probset defintions (bed file and interval_list) format
         # downloaded from UCSC with the download_ucsc_exomes.py script
         dst='exome-probesets/hg38',
@@ -690,6 +690,9 @@ SOURCES = [
             twist_bioscience_core_exome_panel_target_regions_interval_list='Twist_Exome_Target_hg38.interval_list',
             twist_comprehensive_exome_panel_target_regions_bed='Twist_ComprehensiveExome_targets_hg38.bed',
             twist_comprehensive_exome_panel_target_regions_interval_list='Twist_ComprehensiveExome_targets_hg38.interval_list',
+            # Twist Comprehensive Exome + VCGS custom content (Mackenzie's Twist cohort).
+            twist_vcgs_custom_exome_covered_targets_bed='Twist_VCGS_Exome_Covered_Targets_hg38.bed',
+            twist_vcgs_custom_exome_covered_targets_interval_list='Twist_VCGS_Exome_Covered_Targets_hg38.interval_list',
             agilent_sureselect_all_exon_v7_target_regions_bed='S31285117_Regions.bed',
             agilent_sureselect_all_exon_v7_target_regions_interval_list='S31285117_Regions.interval_list',
             agilent_sureselect_all_exon_v7_covered_by_probes_bed='S31285117_Covered.bed',
@@ -722,6 +725,11 @@ SOURCES = [
             agilent_sureselect_clinical_research_exome_v2_target_regions_interval_list='S30409818_Regions.interval_list',
             agilent_sureselect_clinical_research_exome_v2_covered_by_probes_bed='S30409818_Covered.bed',
             agilent_sureselect_clinical_research_exome_v2_covered_by_probes_interval_list='S30409818_Covered.interval_list',
+            # Agilent SureSelect Clinical Research Exome v1 (S06588914), hg19 source lifted via picard.
+            agilent_sureselect_clinical_research_exome_v1_target_regions_bed='S06588914_Regions_hg38.bed',
+            agilent_sureselect_clinical_research_exome_v1_target_regions_interval_list='S06588914_Regions_hg38.interval_list',
+            agilent_sureselect_clinical_research_exome_v1_covered_by_probes_bed='S06588914_Covered_hg38.bed',
+            agilent_sureselect_clinical_research_exome_v1_covered_by_probes_interval_list='S06588914_Covered_hg38.interval_list',
             roche_seqcap_ez_medexome_mito_empirical_target_regions_bed='SeqCap_EZ_MedExomePlusMito_hg38_empirical_targets.bed',
             roche_seqcap_ez_medexome_mito_empirical_target_regions_interval_list='SeqCap_EZ_MedExomePlusMito_hg38_empirical_targets.interval_list',
             roche_seqcap_ez_medexome_mito_capture_probe_footprint_bed='SeqCap_EZ_MedExomePlusMito_hg38_capture_targets.bed',
@@ -742,14 +750,6 @@ SOURCES = [
             idt_xgen_exome_research_panel_v1_target_regions_interval_list='xgen-exome-research-panel-targets-hg38.interval_list',
             idt_xgen_exome_research_panel_v1_probes_bed='xgen-exome-research-panel-probes-hg38.bed',
             idt_xgen_exome_research_panel_v1_probes_interval_list='xgen-exome-research-panel-probes-hg38.interval_list',
-            # Twist Comprehensive Exome + VCGS custom content (Mackenzie's Twist cohort).
-            twist_vcgs_custom_exome_covered_targets_bed='Twist_VCGS_Exome_Covered_Targets_hg38.bed',
-            twist_vcgs_custom_exome_covered_targets_interval_list='Twist_VCGS_Exome_Covered_Targets_hg38.interval_list',
-            # Agilent SureSelect Clinical Research Exome v1 (S06588914), hg19 source lifted via picard.
-            agilent_sureselect_clinical_research_exome_v1_target_regions_bed='Agilent_ClinicalResearchExome_v1_Regions_hg38.bed',
-            agilent_sureselect_clinical_research_exome_v1_target_regions_interval_list='Agilent_ClinicalResearchExome_v1_Regions_hg38.interval_list',
-            agilent_sureselect_clinical_research_exome_v1_covered_by_probes_bed='Agilent_ClinicalResearchExome_v1_Covered_hg38.bed',
-            agilent_sureselect_clinical_research_exome_v1_covered_by_probes_interval_list='Agilent_ClinicalResearchExome_v1_Covered_hg38.interval_list',
             # Superseded by per-design beds (twist_vcgs_custom_*,
             # agilent_sureselect_clinical_research_exome_v{1,2}_*). Retained for any
             # pipeline still pinned to the merged designs.

--- a/references.py
+++ b/references.py
@@ -128,6 +128,13 @@ SOURCES = [
         transfer_cmd=gcs_rsync,
     ),
     Source(
+        'liftover_37_to_38',
+        # Liftover chain file to translate from GRCh37/hg19 to GRCh38 coordinates.
+        src='https://hgdownload.soe.ucsc.edu/goldenPath/hg19/liftOver/hg19ToHg38.over.chain.gz',
+        dst='liftover/hg19ToHg38.over.chain.gz',
+        transfer_cmd=curl,
+    ),
+    Source(
         'somalier_sites',
         # Site list for somalier fingerprinting
         src='https://github.com/brentp/somalier/files/3412456/sites.hg38.vcf.gz',

--- a/references.py
+++ b/references.py
@@ -742,6 +742,17 @@ SOURCES = [
             idt_xgen_exome_research_panel_v1_target_regions_interval_list='xgen-exome-research-panel-targets-hg38.interval_list',
             idt_xgen_exome_research_panel_v1_probes_bed='xgen-exome-research-panel-probes-hg38.bed',
             idt_xgen_exome_research_panel_v1_probes_interval_list='xgen-exome-research-panel-probes-hg38.interval_list',
+            # Twist Comprehensive Exome + VCGS custom content (Mackenzie's Twist cohort).
+            twist_vcgs_custom_exome_covered_targets_bed='Twist_VCGS_Exome_Covered_Targets_hg38.bed',
+            twist_vcgs_custom_exome_covered_targets_interval_list='Twist_VCGS_Exome_Covered_Targets_hg38.interval_list',
+            # Agilent SureSelect Clinical Research Exome v1 (S06588914), hg19 source lifted via picard.
+            agilent_sureselect_clinical_research_exome_v1_target_regions_bed='Agilent_ClinicalResearchExome_v1_Regions_hg38.bed',
+            agilent_sureselect_clinical_research_exome_v1_target_regions_interval_list='Agilent_ClinicalResearchExome_v1_Regions_hg38.interval_list',
+            agilent_sureselect_clinical_research_exome_v1_covered_by_probes_bed='Agilent_ClinicalResearchExome_v1_Covered_hg38.bed',
+            agilent_sureselect_clinical_research_exome_v1_covered_by_probes_interval_list='Agilent_ClinicalResearchExome_v1_Covered_hg38.interval_list',
+            # Superseded by per-design beds (twist_vcgs_custom_*,
+            # agilent_sureselect_clinical_research_exome_v{1,2}_*). Retained for any
+            # pipeline still pinned to the merged designs.
             mackenzie_intersect_exome_probes_bed='mackenzie_intersect_exome_regions.bed',
             mackenzie_intersect_exome_probes_interval_list='mackenzie_intersect_exome_regions.interval_list',
             mackenzie_union_exome_probes_bed='mackenzie_union_exome_regions.bed',

--- a/references.py
+++ b/references.py
@@ -131,7 +131,7 @@ SOURCES = [
         'liftover_37_to_38',
         # Liftover chain file to translate from GRCh37/hg19 to GRCh38 coordinates.
         src='https://hgdownload.soe.ucsc.edu/goldenPath/hg19/liftOver/hg19ToHg38.over.chain.gz',
-        dst='liftover/hg19ToHg38.over.chain.gz',
+        dst='liftover/grch37_to_grch38over.chain.gz',
         transfer_cmd=curl,
     ),
     Source(


### PR DESCRIPTION
## Summary

Adds per-design exome target/probe BEDs for the Mackenzie cohort to
`gs://cpg-common-main/references/`, which downstream unblocks
[dragen_align_pa #44](https://github.com/populationgenomics/dragen_align_pa/pull/44)
(per-cohort exome target BEDs with design-vs-bed fail-fast check). PR #44
introduces three canonical exome designs (`CRE`, `CREv2`, `TWIST`) with
placeholder ICA file IDs that need real BEDs uploaded to ICA — and those BEDs
need to land here first.

New knowledge driving this work:

- "Twist" in the Mackenzie cohort = **Twist Comprehensive Exome + VCGS custom
  content**, not vanilla UCSC Twist Comprehensive. Twist ships a single
  "Covered Targets" BED for this design (hg38).
- A small subset of Mackenzie samples use **Agilent SureSelect Clinical
  Research Exome v1** (S06588914). UCSC only ships this under hg19, so it
  needs liftover to hg38.
- For each Agilent design we want **both** target Regions and Covered probe
  footprints. CREv2 already has both; CRE v1 is being added here to match.

## What changes

**`references.py`:**

- New `Source('liftover_37_to_38', ...)` — UCSC `hg19ToHg38.over.chain.gz` via
  `curl`, mirroring the existing `liftover_38_to_37`.
- New `Source('hg19_fasta', ...)` — UCSC `hg19.fa.gz` via `curl`, plus a
  declared `hg19_dict` sub-path. The fasta lands automatically via CI; the
  `.dict` is generated once via the bootstrap AR job (see operational
  checklist).
- Six new entries on the existing `exome_probesets` Source:
  - `twist_vcgs_custom_exome_covered_targets_{bed,interval_list}`
  - `agilent_sureselect_clinical_research_exome_v1_target_regions_{bed,interval_list}`
  - `agilent_sureselect_clinical_research_exome_v1_covered_by_probes_{bed,interval_list}`
- Deprecation comment over the existing `mackenzie_intersect_*` /
  `mackenzie_union_*` entries — kept in-place, marked superseded by the
  per-design entries above.

**`exome_designs/` (four new scripts + README updates):**

- `get_twist_vcgs_custom.sh` — trivial `curl` of the Twist VCGS hg38 Covered
  Targets BED.
- `download_hg19_agilent_cre_v1.py` — local download of S06588914 Regions +
  Covered BEDs (hg19) via UCSC API, mirroring `download_ucsc_exomes.py`.
- `generate_hg19_dict.py` — one-shot AR job that `picard
  CreateSequenceDictionary`'s the hg19 fasta into `gs://cpg-common-main/.../hg19.dict`.
- `liftover_and_convert_hg19_bedfiles.py` — AR job that picks up any
  `*_hg19.bed` staged under `gs://cpg-common-test/references/exome-probesets/hg19/`
  and runs `BedToIntervalList → LiftOverIntervalList → IntervalListToBed`
  inside the picard image, copying the hg38 outputs to `cpg-common-main`.
  Logs rejected-interval counts in batch logs for sanity-checking.
- `README.md` — new sections covering the Twist VCGS download, the Agilent
  CRE v1 hg19→hg38 workflow (download / one-time dict bootstrap / liftover),
  and the `hg19/` vs `hg38/` subfolder layout under
  `cpg-common-test/references/exome-probesets/`.

## Operational checklist (post-merge)

Reproduced inline so reviewers can see the full pipeline-to-ICA path:

1. Locally: `bash exome_designs/get_twist_vcgs_custom.sh` and
   `python exome_designs/download_hg19_agilent_cre_v1.py`.
2. `gcloud storage cp` outputs to their build-matched subfolders under
   `gs://cpg-common-test/references/exome-probesets/`:
   - `hg38/Twist_VCGS_Exome_Covered_Targets_hg38.bed`
   - `hg19/Agilent_ClinicalResearchExome_v1_Regions_hg19.bed`
   - `hg19/Agilent_ClinicalResearchExome_v1_Covered_hg19.bed`
3. Merge this PR. CI auto-transfers `liftover_37_to_38` and `hg19_fasta`.
4. AR-run `generate_hg19_dict.py` once → `hg19.dict` lands in `cpg-common-main`.
5. AR-run `liftover_and_convert_hg19_bedfiles.py` → CRE v1 hg38 BEDs +
   interval_lists in `cpg-common-main`.
6. AR-run `convert_bedfiles_to_interval_lists.py` → Twist hg38 interval_list
   in `cpg-common-main`.
7. Pull each of the three hg38 BEDs from `cpg-common-main`, upload to ICA via
   `icav2`, capture `fil.*` IDs, then replace the three
   `PLACEHOLDER-*-bed-not-yet-uploaded-to-ica` strings in `dragen_align_pa`
   constants + per-cohort TOMLs (follow-up PR).

## CRE v1 liftover loss

`liftover_and_convert_hg19_bedfiles.py` logs the rejected-interval count from
`picard LiftOverIntervalList` in batch logs. Single-digit-percent loss is
expected for a Clinical Research Exome design; reviewer should sanity-check
the count against the manufacturer-portal hg38 baseline at
`/Users/jossch/Downloads/S06588914/` (interval count + total bp) before
treating the hg38 BEDs as ICA-ready.

## Deprecated entries

`mackenzie_intersect_*` / `mackenzie_union_*` entries on `exome_probesets`
are retained and marked superseded by per-design beds in a comment above
them. No bucket-side deletion — kept around for any pipeline still pinned to
the merged designs.