### PR TITLE
Cre v1 regions only

### DIFF
--- a/exome_designs/README.md
+++ b/exome_designs/README.md
@@ -68,13 +68,15 @@ The matching hg38 `interval_list` is produced by the standard
 
 Agilent SureSelect Clinical Research Exome v1 (design id `S06588914`) is only
 distributed by UCSC at hg19, so a manual liftover step is required before the
-hg38 BEDs land in references.
+hg38 BED lands in references. Only the Regions BED is shipped: CRE v1 is built
+on the SureSelectXT All Exon V5 backbone (exon-resolution design), so Agilent's
+Regions and Covered BEDs are identical by construction.
 
-### 1. Download hg19 BEDs
+### 1. Download hg19 BED
 
 ```
 python download_hg19_agilent_cre_v1.py
-gcloud storage cp Agilent_ClinicalResearchExome_v1_*_hg19.bed \
+gcloud storage cp S06588914_Regions_hg19.bed \
     gs://cpg-common-test/references/exome-probesets/hg19/
 ```
 
@@ -97,7 +99,7 @@ analysis-runner \
 
 Chains `picard BedToIntervalList → LiftOverIntervalList → IntervalListToBed` per
 `*_hg19.bed` in `cpg-common-test`, writes the hg38 BED + interval_list to the
-paths declared in `references.py` under `exome_probesets`, and logs the count of
+paths declared in `references.py` under `exome_probesets_hg38`, and logs the count of
 rejected intervals so the operator can sanity-check liftover loss before
 promoting the BEDs.
 
@@ -110,10 +112,12 @@ analysis-runner \
     liftover_and_convert_hg19_bedfiles.py
 ```
 
-### Sanity-check post-liftover
+### Sanity-check post-download
 
-Agilent's portal ships hg38 directly. Compare interval counts and total bp of
-the lifted `_hg38.bed` outputs against the portal baseline at
-`/Users/jossch/Downloads/S06588914/S06588914_{Regions,Covered}.bed` before
-promoting the BEDs into ICA. Those files are not the source of truth — only a
-reference for diffing.
+Neither Agilent nor UCSC ships an hg38 baseline for CRE v1 — the manufacturer
+portal also only distributes hg19. Compare interval count and total bp of the
+downloaded `S06588914_Regions_hg19.bed` against the portal baseline at
+`/Users/jossch/Downloads/S06588914/S06588914_Regions.bed` (both hg19) to
+confirm the UCSC track matches the manufacturer's design before running
+liftover. After liftover, expect a small (single-digit-percent) drop from
+intervals that fail to map to hg38; the picard job logs the rejected count.

--- a/exome_designs/README.md
+++ b/exome_designs/README.md
@@ -8,6 +8,15 @@ for each exome data cohort (and sub-cohort cf. Mackenzie's mission).
 [UCSC Genome browser](https://genome.ucsc.edu/index.html) has 'tracks' for many of the most common
 exome probesets.
 
+## Probe design glossary 
+
+- Targets:  An input list of features the design should capture. Often a plain list of transcript/CCDS IDs
+- Regions:  The genomic coordinates resolved from those target IDs
+- Covered:  The intervals actually covered by probe (bait) tiling on the array. Usually a larger size (in MB) than Regions.
+- Padded: Covered intervals extended by a fixed flank on each side (e.g. +- 50 or 100 bp). Could be used for variant discovery. 
+
+Mental model: Targets (IDs) → Regions (what we wanted to capture, in coords) → Covered (what the baits actually capture) → Padded (Covered + flank for QC).
+
 ## Get exome probesets
 
 use `download_ucsc_exomes.py` to retrieve the available exomes, and convert them from BigBed to Bed format.
@@ -66,11 +75,7 @@ The matching hg38 `interval_list` is produced by the standard
 
 ## Agilent CRE v1 (hg19 → hg38 liftover)
 
-Agilent SureSelect Clinical Research Exome v1 (design id `S06588914`) is only
-distributed by UCSC at hg19, so a manual liftover step is required before the
-hg38 BED lands in references. Only the Regions BED is shipped: CRE v1 is built
-on the SureSelectXT All Exon V5 backbone (exon-resolution design), so Agilent's
-Regions and Covered BEDs are identical by construction.
+The design id is `S06588914`. We can also get this from UCSC, but it is only on hg19 assembly, so a manual liftover to hg38 is required. Unlike CREv2, there is no difference between regions and covered - it is a covred (lergest) definition. 
 
 ### 1. Download hg19 BED
 
@@ -112,17 +117,7 @@ analysis-runner \
     liftover_and_convert_hg19_bedfiles.py
 ```
 
-### Sanity-check post-download
-
-Neither Agilent nor UCSC ships an hg38 baseline for CRE v1 — the manufacturer
-portal also only distributes hg19. Compare interval count and total bp of the
-downloaded `S06588914_Regions_hg19.bed` against the portal baseline at
-`/Users/jossch/Downloads/S06588914/S06588914_Regions.bed` (both hg19) to
-confirm the UCSC track matches the manufacturer's design before running
-liftover. After liftover, expect a small (single-digit-percent) drop from
-intervals that fail to map to hg38; the picard job logs the rejected count.
-
-## One-shot maintenance
+# Maintenance
 
 ### Rename liftover_37_to_38 chain typo
 

--- a/exome_designs/convert_bedfiles_to_interval_lists.py
+++ b/exome_designs/convert_bedfiles_to_interval_lists.py
@@ -15,7 +15,7 @@ analysis-runner \
 NOTES:
 1. Run in MAIN!
 2. Assumes bedfiles are in TEST.
-3. Defaults to references source exome_probesets and hg38: references/exome-probesets/hg38
+3. Defaults to references source exome_probesets_hg38 and hg38: references/exome-probesets/hg38
 4. Copies BED and INTERVAL_LIST to cpg-common-main
 5. Takes a glob of the bed_source path: if re-run and previously converted BED files are still in test, they will be converted anew.
 
@@ -36,7 +36,7 @@ from cloudpathlib import AnyPath, CloudPath
 from cpg_utils.config import ConfigError, config_retrieve, cpg_test_dataset_path, reference_path
 from cpg_utils.hail_batch import get_batch, image_path
 
-SOURCE = 'exome_probesets'
+SOURCE = 'exome_probesets_hg38'
 
 
 def get_bedfile_paths(exome_path: str) -> Iterator[Path] | Generator[CloudPath, None, None]:
@@ -71,8 +71,8 @@ def make_interval_lists(bedfile_paths: Iterator[Path] | Generator[CloudPath, Non
 
         # lookup the bed and interval_list outpaths by matching their 'resource name' in references. will FAIL
         # if not in references.py
-        bed_out_path = reference_path('exome_probesets/' + exome_ref_dict[bed_file])
-        interval_list_out_path = reference_path('exome_probesets/' + exome_ref_dict[bed_stem + '.interval_list'])
+        bed_out_path = reference_path(f'{SOURCE}/' + exome_ref_dict[bed_file])
+        interval_list_out_path = reference_path(f'{SOURCE}/' + exome_ref_dict[bed_stem + '.interval_list'])
 
         picard_job.command(
             f"""

--- a/exome_designs/download_hg19_agilent_cre_v1.py
+++ b/exome_designs/download_hg19_agilent_cre_v1.py
@@ -6,19 +6,9 @@ Regions BED from UCSC at hg19 coordinates. Output:
 
   - S06588914_Regions_hg19.bed
 
-CRE v1 is built on the SureSelectXT All Exon V5 backbone, which was specified
-at exon resolution; Agilent ships Regions = Covered for this design by
-construction (the portal Regions track header literally reads "This is same as
-Covered.bed"), so only the Regions BED is downloaded. CREv2 (S30409818), a
-ground-up redesign with sub-exon target resolution, keeps both files via
-download_ucsc_exomes.py.
-
 The hg19 BED is an intermediate artifact: upload it to cpg-common-test and
 lift over to hg38 with liftover_and_convert_hg19_bedfiles.py.
 
-Manufacturer-portal baseline (hg19, also distributed by Agilent in hg19 only)
-for sanity-check comparison against the UCSC track downloaded here:
-    /Users/jossch/Downloads/S06588914/S06588914_Regions.bed
 """
 
 import urllib.parse as up

--- a/exome_designs/download_hg19_agilent_cre_v1.py
+++ b/exome_designs/download_hg19_agilent_cre_v1.py
@@ -16,10 +16,9 @@ download_ucsc_exomes.py.
 The hg19 BED is an intermediate artifact: upload it to cpg-common-test and
 lift over to hg38 with liftover_and_convert_hg19_bedfiles.py.
 
-Manufacturer-portal baseline for sanity-check comparison post-liftover:
+Manufacturer-portal baseline (hg19, also distributed by Agilent in hg19 only)
+for sanity-check comparison against the UCSC track downloaded here:
     /Users/jossch/Downloads/S06588914/S06588914_Regions.bed
-Agilent's portal ships hg38 directly; that file is not the source here, only a
-reference for interval-count / total-bp diffs after liftover.
 """
 
 import urllib.parse as up

--- a/exome_designs/download_hg19_agilent_cre_v1.py
+++ b/exome_designs/download_hg19_agilent_cre_v1.py
@@ -1,21 +1,25 @@
 #!/usr/bin/env python3
 
 """
-Download Agilent SureSelect Clinical Research Exome v1 (S06588914) probeset
-BED files from UCSC at hg19 coordinates. Outputs two files in the current
-directory:
+Download the Agilent SureSelect Clinical Research Exome v1 (S06588914)
+Regions BED from UCSC at hg19 coordinates. Output:
 
-  - Agilent_ClinicalResearchExome_v1_Regions_hg19.bed
-  - Agilent_ClinicalResearchExome_v1_Covered_hg19.bed
+  - S06588914_Regions_hg19.bed
 
-These hg19 BEDs are intermediate artifacts: upload them to cpg-common-test
-and then lift over to hg38 with liftover_and_convert_hg19_bedfiles.py.
+CRE v1 is built on the SureSelectXT All Exon V5 backbone, which was specified
+at exon resolution; Agilent ships Regions = Covered for this design by
+construction (the portal Regions track header literally reads "This is same as
+Covered.bed"), so only the Regions BED is downloaded. CREv2 (S30409818), a
+ground-up redesign with sub-exon target resolution, keeps both files via
+download_ucsc_exomes.py.
+
+The hg19 BED is an intermediate artifact: upload it to cpg-common-test and
+lift over to hg38 with liftover_and_convert_hg19_bedfiles.py.
 
 Manufacturer-portal baseline for sanity-check comparison post-liftover:
     /Users/jossch/Downloads/S06588914/S06588914_Regions.bed
-    /Users/jossch/Downloads/S06588914/S06588914_Covered.bed
-Agilent's portal ships hg38 directly; those files are not the source here,
-only a reference for interval-count / total-bp diffs after liftover.
+Agilent's portal ships hg38 directly; that file is not the source here, only a
+reference for interval-count / total-bp diffs after liftover.
 """
 
 import urllib.parse as up
@@ -32,8 +36,7 @@ GENOME = 'hg19'
 CANONICAL_CHRS = [f'chr{x}' for x in list(range(1, 23)) + ['X', 'Y', 'M']]
 TARGET_DESIGN_ID = 'S06588914'
 OUTPUT_FILENAMES = {
-    'regions': 'Agilent_ClinicalResearchExome_v1_Regions_hg19.bed',
-    'covered': 'Agilent_ClinicalResearchExome_v1_Covered_hg19.bed',
+    'regions': 'S06588914_Regions_hg19.bed',
 }
 
 
@@ -55,14 +58,19 @@ def find_design_tracks(
     probesets: dict[str, dict], design_id: str,
 ) -> dict[str, str]:
     """
-    Locate the Regions and Covered BigBed URLs for the given Agilent design id
+    Locate the Regions BigBed URL for the given Agilent design id
     (e.g. ``S06588914``) within the UCSC exomeProbesets track listing. Matches
-    by BigBed filename stem (``<design>_Regions`` / ``<design>_Covered``) and
-    cross-checks the track ``shortLabel`` for the design id.
+    by BigBed filename stem (``<design>_Regions``) and cross-checks the track
+    ``shortLabel`` for the design id.
     """
 
     matches: dict[str, str] = {}
     for track in probesets.values():
+        # UCSC nests parent composite-track metadata (compositeContainer,
+        # shortLabel, etc.) as plain strings alongside the per-track dicts;
+        # skip those.
+        if not isinstance(track, dict):
+            continue
         url = track.get('bigDataUrl', '')
         if not url:
             continue
@@ -73,9 +81,7 @@ def find_design_tracks(
             continue
         if stem.endswith('_Regions'):
             matches['regions'] = url
-        elif stem.endswith('_Covered'):
-            matches['covered'] = url
-    missing = {'regions', 'covered'} - matches.keys()
+    missing = {'regions'} - matches.keys()
     if missing:
         raise RuntimeError(
             f'Could not locate {design_id} hg19 entries for: {sorted(missing)}',
@@ -110,7 +116,7 @@ def write_bed_from_bigbed(
 
 def main() -> None:
     """
-    Download Regions + Covered hg19 BEDs for Agilent CRE v1 (S06588914).
+    Download the Regions hg19 BED for Agilent CRE v1 (S06588914).
     """
 
     probesets = get_exome_probesets(API_URL, TRACK_ENDPOINT, GENOME)

--- a/exome_designs/download_ucsc_exomes.py
+++ b/exome_designs/download_ucsc_exomes.py
@@ -16,7 +16,7 @@ GENOME_ENDPOINT = '/list/ucscGenomes'
 TRACK_ENDPOINT = '/list/tracks'
 GENOME = 'hg38'
 CANONICAL_CHRS = [f'chr{x}' for x in list(range(1, 23)) + ['X', 'Y', 'M']]
-SOURCE_NAME = 'exome_probesets'
+SOURCE_NAME = 'exome_probesets_hg38'
 CPG_DEST = 'exome-probesets/hg38/'
 
 

--- a/exome_designs/liftover_and_convert_hg19_bedfiles.py
+++ b/exome_designs/liftover_and_convert_hg19_bedfiles.py
@@ -25,7 +25,7 @@ NOTES:
      picard LiftOverIntervalList (hg19 -> hg38 interval_list, target SD=broad)
      picard IntervalListToBed    (hg38 interval_list -> hg38 BED)
 5. Both the BED and interval_list output filenames (with _hg19 substituted for
-   _hg38) must exist in references.py under the exome_probesets Source.
+   _hg38) must exist in references.py under the exome_probesets_hg38 Source.
 6. Logs the count of rejected intervals from picard LiftOverIntervalList so
    the operator can sanity-check liftover loss before merging into ICA.
 """
@@ -40,7 +40,7 @@ from cloudpathlib import AnyPath, CloudPath
 from cpg_utils.config import ConfigError, config_retrieve, cpg_test_dataset_path, reference_path
 from cpg_utils.hail_batch import get_batch, image_path
 
-SOURCE = 'exome_probesets'
+SOURCE = 'exome_probesets_hg38'
 
 
 def get_hg19_bedfile_paths(exome_path: str) -> Iterator[Path] | Generator[CloudPath, None, None]:
@@ -161,7 +161,7 @@ def main(exome_path, hg38_sd_ref, chain_ref, hg19_dict_ref):
     """
     Lift over hg19 exome BED files in cpg-common-test to hg38 with picard,
     and write hg38 BED + interval_list outputs to the paths declared in
-    references.py under exome_probesets.
+    references.py under exome_probesets_hg38.
     """
 
     bedfile_paths = get_hg19_bedfile_paths(exome_path)

--- a/references.py
+++ b/references.py
@@ -726,10 +726,13 @@ SOURCES = [
             agilent_sureselect_clinical_research_exome_v2_covered_by_probes_bed='S30409818_Covered.bed',
             agilent_sureselect_clinical_research_exome_v2_covered_by_probes_interval_list='S30409818_Covered.interval_list',
             # Agilent SureSelect Clinical Research Exome v1 (S06588914), hg19 source lifted via picard.
+            # CRE v1 is built on the SureSelectXT All Exon V5 backbone, which was specified at exon
+            # resolution; Regions and Covered intervals are identical by construction (Agilent's
+            # portal Regions track header literally says "This is same as Covered.bed"). Only the
+            # Regions BED is shipped. CREv2 (S30409818) is a ground-up redesign with distinct
+            # sub-exon Regions vs probe-footprint Covered, so it keeps both entries.
             agilent_sureselect_clinical_research_exome_v1_target_regions_bed='S06588914_Regions_hg38.bed',
             agilent_sureselect_clinical_research_exome_v1_target_regions_interval_list='S06588914_Regions_hg38.interval_list',
-            agilent_sureselect_clinical_research_exome_v1_covered_by_probes_bed='S06588914_Covered_hg38.bed',
-            agilent_sureselect_clinical_research_exome_v1_covered_by_probes_interval_list='S06588914_Covered_hg38.interval_list',
             roche_seqcap_ez_medexome_mito_empirical_target_regions_bed='SeqCap_EZ_MedExomePlusMito_hg38_empirical_targets.bed',
             roche_seqcap_ez_medexome_mito_empirical_target_regions_interval_list='SeqCap_EZ_MedExomePlusMito_hg38_empirical_targets.interval_list',
             roche_seqcap_ez_medexome_mito_capture_probe_footprint_bed='SeqCap_EZ_MedExomePlusMito_hg38_capture_targets.bed',


### PR DESCRIPTION
Drop the redundant CRE v1 Covered BED entries (V5-backbone design — Regions and Covered are identical), fix the hg19 downloader's UCSC composite-track `AttributeError`, and repoint the AR helper scripts at the renamed `exome_probesets_hg38` Source.