### PR TITLE
Fix liftover_37_to_38 chain filename typo

### DIFF
--- a/exome_designs/README.md
+++ b/exome_designs/README.md
@@ -117,3 +117,25 @@ the lifted `_hg38.bed` outputs against the portal baseline at
 `/Users/jossch/Downloads/S06588914/S06588914_{Regions,Covered}.bed` before
 promoting the BEDs into ICA. Those files are not the source of truth — only a
 reference for diffing.
+
+## One-shot maintenance
+
+### Rename liftover_37_to_38 chain typo
+
+PR #96 landed the `liftover_37_to_38` chain at a typo'd path
+(`grch37_to_grch38over.chain.gz` — missing a `.` before `over`). A follow-up
+references PR corrects the Source `dst` to `grch37_to_grch38.over.chain.gz`,
+and CI auto-curls the 228 KB chain to the corrected path on merge — leaving
+the typo'd blob as an orphan in `cpg-common-main`. Run this script once
+post-merge to delete it. The script is idempotent: it renames if only the
+typo'd path exists, deletes the typo'd path if both exist, and no-ops if only
+the corrected path is present.
+
+```
+analysis-runner \
+    --dataset common \
+    --access-level full \
+    --description 'Rename liftover_37_to_38 chain typo' \
+    --output-dir references/liftover-rename \
+    rename_liftover_chain_typo.sh
+```

--- a/exome_designs/rename_liftover_chain_typo.sh
+++ b/exome_designs/rename_liftover_chain_typo.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+
+# One-shot cleanup for the liftover_37_to_38 chain filename typo. PR #96 landed
+# the chain at the typo'd path (missing a `.` before `over`):
+#     gs://cpg-common-main/references/liftover/grch37_to_grch38over.chain.gz
+# The companion references-repo PR corrects the Source `dst` to
+# `grch37_to_grch38.over.chain.gz`; CI auto-curls the 228 KB chain to the
+# corrected path on merge. This script removes the typo'd blob.
+#
+# analysis-runner \
+#     --dataset common \
+#     --access-level full \
+#     --description 'Rename liftover_37_to_38 chain typo' \
+#     --output-dir references/liftover-rename \
+#     rename_liftover_chain_typo.sh
+#
+# Idempotent: handles old-only (rename), both-present (delete old), and
+# new-only (no-op) states. Errors if neither blob is present.
+
+set -euo pipefail
+
+OLD='gs://cpg-common-main/references/liftover/grch37_to_grch38over.chain.gz'
+NEW='gs://cpg-common-main/references/liftover/grch37_to_grch38.over.chain.gz'
+
+if gcloud storage objects describe "$OLD" >/dev/null 2>&1; then
+    old_exists=1
+else
+    old_exists=0
+fi
+
+if gcloud storage objects describe "$NEW" >/dev/null 2>&1; then
+    new_exists=1
+else
+    new_exists=0
+fi
+
+if (( old_exists == 0 && new_exists == 1 )); then
+    echo "Typo blob already absent; corrected blob at $NEW. Nothing to do."
+    exit 0
+fi
+
+if (( old_exists == 0 && new_exists == 0 )); then
+    echo "Neither $OLD nor $NEW exists. Has the references-repo PR correcting liftover_37_to_38 dst merged and CI run?" >&2
+    exit 1
+fi
+
+if (( old_exists == 1 && new_exists == 0 )); then
+    gcloud storage mv "$OLD" "$NEW"
+else
+    gcloud storage rm "$OLD"
+fi

--- a/references.py
+++ b/references.py
@@ -131,7 +131,7 @@ SOURCES = [
         'liftover_37_to_38',
         # Liftover chain file to translate from GRCh37/hg19 to GRCh38 coordinates.
         src='https://hgdownload.soe.ucsc.edu/goldenPath/hg19/liftOver/hg19ToHg38.over.chain.gz',
-        dst='liftover/grch37_to_grch38over.chain.gz',
+        dst='liftover/grch37_to_grch38.over.chain.gz',
         transfer_cmd=curl,
     ),
     Source(


### PR DESCRIPTION
## Summary

PR #96 had a typo in `dst`:
`liftover/grch37_to_grch38over.chain.gz` (missing a `.` before `over`). This PR corrects the `dst` and
adds a one-shot AR script to clean up the orphan that CI will leave behind
after auto-retransferring to the corrected path.

## What changes

- `references.py`: `liftover_37_to_38` `dst` corrected to
  `liftover/grch37_to_grch38.over.chain.gz`.
- `exome_designs/rename_liftover_chain_typo.sh` (new): bare bash script run
  via analysis-runner against `--dataset common --access-level full`. Probes
  both paths and branches — `mv` if only the typo'd blob is present, `rm` if
  both are present (CI already curl'd the corrected one), no-op if only the
  corrected blob is present, error if neither.
- `exome_designs/README.md`: new "One-shot maintenance" section documenting
  when and how to run the script.