### PR TITLE
GDA biallelic SNV BED from BPM manifest

### DIFF
--- a/illumina_microarray/run_generate_bed_from_illumina_bpm.py
+++ b/illumina_microarray/run_generate_bed_from_illumina_bpm.py
@@ -1,0 +1,93 @@
+#!/usr/bin/env python3
+
+"""
+Driver that submits a Hail Batch job to generate
+GDA-8v1-0_D2-biallelic-snps.bed from the Illumina GDA BPM manifest, polarised
+against the GRCh38 fasta. Both inputs already live under
+gs://cpg-common-main/references/illumina_microarray/.
+
+analysis-runner \
+    --dataset common \
+    --access-level full \
+    --description 'Generate GDA biallelic SNV BED from BPM manifest' \
+    --output-dir references/illumina_microarray \
+    illumina_microarray/run_generate_bed_from_illumina_bpm.py
+
+NOTES:
+1. The output filename is fixed at GDA-8v1-0_D2-biallelic-snps.bed, matching
+   the `GDA_8v1_0_D2_biallelic_snps_bed` entry under the `illumina_microarray`
+   Source in references.py.
+2. Idempotent: exits without submitting a batch if the BED is already present
+   at the canonical references path.
+3. Run at --access-level full --dataset common to land outputs at the
+   canonical references location (gs://cpg-common-main/references/...).
+   --access-level test writes to gs://cpg-common-test/references/... for
+   staging/validation.
+4. The worker (reference_generating_scripts/generate_bed_from_illumina_bpm.py)
+   is shipped into the Batch job via a base64 heredoc, and its only deps
+   (numpy, pyfaidx, IlluminaBeadArrayFiles) are pip-installed at job start in
+   a plain python:3.11-slim image — no custom image needed.
+"""
+
+import base64
+from pathlib import Path
+
+from cloudpathlib import AnyPath
+from cpg_utils.config import output_path, reference_path
+from cpg_utils.hail_batch import get_batch, image_path
+
+
+OUTPUT_FILENAME = 'GDA-8v1-0_D2-biallelic-snps.bed'
+REPO_ROOT = Path(__file__).resolve().parent.parent
+WORKER_SCRIPT = REPO_ROOT / 'reference_generating_scripts' / 'generate_bed_from_illumina_bpm.py'
+
+
+def main() -> None:
+    bpm_path = reference_path('illumina_microarray/GDA_8v1_0_D2_bpm')
+    fasta_path = reference_path(
+        'illumina_microarray/GCA_000001405_15_GRCh38_no_alt_analysis_set_fna',
+    )
+    fai_path = reference_path(
+        'illumina_microarray/GCA_000001405_15_GRCh38_no_alt_analysis_set_fna_fai',
+    )
+    bed_out_path = output_path(OUTPUT_FILENAME)
+
+    if AnyPath(bed_out_path).exists():
+        print(f'{OUTPUT_FILENAME} already present at {bed_out_path}; nothing to do.')
+        return
+
+    worker_b64 = base64.b64encode(WORKER_SCRIPT.read_bytes()).decode()
+
+    b = get_batch()
+    bpm_input = b.read_input(bpm_path)
+    # Dotted keys are supported: Batch localises these as {root}.fna and
+    # {root}.fna.fai, which is what pyfaidx's default index lookup expects.
+    fasta_group = b.read_input_group(**{'fna': fasta_path, 'fna.fai': fai_path})
+
+    job = b.new_job(name='Generate GDA biallelic SNV BED from BPM')
+    job.image(image_path('python'))
+    job.storage('20Gi')
+    job.cpu(2)
+    job.memory('8Gi')
+
+    job.command(
+        f"""
+        set -euo pipefail
+        pip install --quiet --no-cache-dir \\
+            numpy pyfaidx \\
+            git+https://github.com/Illumina/BeadArrayFiles.git
+
+        echo {worker_b64} | base64 -d > $BATCH_TMPDIR/generate_bed.py
+        python3 $BATCH_TMPDIR/generate_bed.py \\
+            --bpm {bpm_input} \\
+            --fasta {fasta_group.fna} \\
+            --output {job.ofile}
+        """,
+    )
+
+    b.write_output(job.ofile, bed_out_path)
+    b.run(wait=False)
+
+
+if __name__ == '__main__':
+    main()

--- a/reference_generating_scripts/generate_bed_from_illumina_bpm.py
+++ b/reference_generating_scripts/generate_bed_from_illumina_bpm.py
@@ -1,0 +1,159 @@
+#!/usr/bin/env python3
+
+"""
+Parse an Illumina BPM (Bead Pool Manifest) and emit a BED6+3 of biallelic SNV
+sites, polarised REF/ALT against a reference assembly fasta.
+
+Output columns (tab-separated):
+    chrom  chromStart  chromEnd  name  score(=0)  strand(=RefStrand)
+    REF  ALT  SourceStrand
+
+Drops:
+    - unmapped probes (Chr == '0' or MapInfo == 0)
+    - PAR probes (Chr == 'XY')
+    - non-SNV probes (SNP alleles outside {A,C,G,T}; excludes [I/D]/[D/I])
+    - probes with Unknown RefStrand
+    - sites where neither manifest allele matches the reference base
+
+Chromosome mapping (manifest -> assembly): 'MT' -> 'chrM'; otherwise 'chr' is
+prepended.
+
+Dependencies:
+    pip install pyfaidx
+    pip install git+https://github.com/Illumina/BeadArrayFiles.git
+"""
+
+import sys
+from argparse import ArgumentParser
+
+from IlluminaBeadArrayFiles import BeadPoolManifest, RefStrand, SourceStrand
+from pyfaidx import Fasta
+
+
+COMP = str.maketrans('ACGT', 'TGCA')
+ACGT = set('ACGT')
+OUTPUT_SUFFIX = '-biallelic-snps.bed'
+
+
+def chrom_to_assembly(chrom: str) -> str | None:
+    if chrom in ('0', 'XY', ''):
+        return None
+    if chrom == 'MT':
+        return 'chrM'
+    return f'chr{chrom}'
+
+
+def ref_strand_symbol(rs: int) -> str | None:
+    if rs == RefStrand.Plus:
+        return '+'
+    if rs == RefStrand.Minus:
+        return '-'
+    return None
+
+
+def source_strand_symbol(ss: int) -> str:
+    if ss == SourceStrand.Forward:
+        return 'F'
+    if ss == SourceStrand.Reverse:
+        return 'R'
+    return '.'
+
+
+def parse_snp(snp: str) -> tuple[str, str] | None:
+    """Parse SNP designation '[X/Y]' into (X, Y); None if malformed or non-SNV."""
+    if len(snp) != 5 or snp[0] != '[' or snp[2] != '/' or snp[4] != ']':
+        return None
+    a, b = snp[1], snp[3]
+    if a not in ACGT or b not in ACGT:
+        return None
+    return a, b
+
+
+def main(bpm_path: str, fasta_path: str, output_path: str) -> None:
+    manifest = BeadPoolManifest(bpm_path)
+    fasta = Fasta(fasta_path, sequence_always_upper=True, as_raw=True)
+
+    counts = {
+        'total': manifest.num_loci,
+        'unmapped': 0,
+        'par': 0,
+        'non_snv': 0,
+        'unknown_strand': 0,
+        'missing_contig': 0,
+        'ref_mismatch': 0,
+        'written': 0,
+    }
+
+    with open(output_path, 'w') as out:
+        for i in range(manifest.num_loci):
+            chrom_in = manifest.chroms[i]
+            pos = manifest.map_infos[i]
+
+            if chrom_in == '0' or pos == 0:
+                counts['unmapped'] += 1
+                continue
+            if chrom_in == 'XY':
+                counts['par'] += 1
+                continue
+
+            alleles = parse_snp(manifest.snps[i])
+            if alleles is None:
+                counts['non_snv'] += 1
+                continue
+
+            strand = ref_strand_symbol(manifest.ref_strands[i])
+            if strand is None:
+                counts['unknown_strand'] += 1
+                continue
+
+            a1, a2 = alleles
+            if strand == '-':
+                a1 = a1.translate(COMP)
+                a2 = a2.translate(COMP)
+
+            chrom = chrom_to_assembly(chrom_in)
+            if chrom is None or chrom not in fasta:
+                counts['missing_contig'] += 1
+                continue
+
+            ref_base = fasta[chrom][pos - 1]
+            if ref_base == a1:
+                ref, alt = a1, a2
+            elif ref_base == a2:
+                ref, alt = a2, a1
+            else:
+                counts['ref_mismatch'] += 1
+                continue
+
+            out.write(
+                f'{chrom}\t{pos - 1}\t{pos}\t{manifest.names[i]}\t0\t{strand}\t'
+                f'{ref}\t{alt}\t{source_strand_symbol(manifest.source_strands[i])}\n'
+            )
+            counts['written'] += 1
+
+    width = max(len(k) for k in counts)
+    for k, v in counts.items():
+        print(f'{k:<{width}}  {v}', file=sys.stderr)
+
+
+def cli_main():
+    parser = ArgumentParser(description=__doc__)
+    parser.add_argument('--bpm', required=True, help='Illumina BPM manifest file')
+    parser.add_argument(
+        '--fasta',
+        required=True,
+        help='Reference fasta (must be indexed; .fai alongside)',
+    )
+    parser.add_argument(
+        '--output',
+        required=True,
+        help=f"Output BED path; must end with '{OUTPUT_SUFFIX}'",
+    )
+    args = parser.parse_args()
+    if not args.output.endswith(OUTPUT_SUFFIX):
+        parser.error(f"--output must end with '{OUTPUT_SUFFIX}'")
+    main(args.bpm, args.fasta, args.output)
+
+
+if __name__ == '__main__':
+    cli_main()

--- a/references.py
+++ b/references.py
@@ -860,7 +860,11 @@ SOURCES = [
             GCA_000001405_15_GRCh38_no_alt_analysis_set_fna='GCA_000001405.15_GRCh38_no_alt_analysis_set.fna',
             GCA_000001405_15_GRCh38_no_alt_analysis_set_fna_fai='GCA_000001405.15_GRCh38_no_alt_analysis_set.fna.fai',
             GDA_8v1_0_D1_ClusterFile_egt='GDA-8v1-0_D1_ClusterFile.egt',
-            GDA_8v1_0_D2_bpm='GDA-8v1-0_D2.bpm'
+            GDA_8v1_0_D2_bpm='GDA-8v1-0_D2.bpm',
+            # Biallelic SNV BED derived from the BPM, polarised against the
+            # GRCh38 fasta. Produced by
+            # illumina_microarray/run_generate_bed_from_illumina_bpm.py.
+            GDA_8v1_0_D2_biallelic_snps_bed='GDA-8v1-0_D2-biallelic-snps.bed',
         )
 
     )


### PR DESCRIPTION
## Summary

Adds a script that parses the Illumina GDA-8v1-0_D2 BPM manifest and writes a biallelic SNV BED to `references/illumina_microarray/GDA-8v1-0_D2-biallelic-snps.bed`, polarised against the GRCh38 fasta. Drives it from analysis-runner so the references bucket is the single output destination.

## Changes

- `reference_generating_scripts/generate_bed_from_illumina_bpm.py` — worker. Reads the BPM with `IlluminaBeadArrayFiles`, drops unmapped (Chr=0/MapInfo=0), PAR (Chr=XY), and non-SNV ([I/D]/[D/I]) probes, complements alleles when `RefStrand=-`, and looks up the reference base via `pyfaidx` to assign REF vs ALT. Emits BED6+3: `chrom, start, end, Name, 0, RefStrand, REF, ALT, SourceStrand`. Skips and counts the handful of sites where neither allele matches the fasta.
- `illumina_microarray/run_generate_bed_from_illumina_bpm.py` — analysis-runner driver. Submits one Hail Batch job under `image_path('python')`, pip-installs `numpy`, `pyfaidx`, and `IlluminaBeadArrayFiles` (git), embeds the worker via base64, and writes the BED back to references through `output_path()`. Idempotent: no-ops if the output already exists.
- `references.py` — new `GDA_8v1_0_D2_biallelic_snps_bed` entry under the existing `illumina_microarray` Source. No `src`/`transfer_cmd`; the path is declared and AR populates it.

## test (local)

Ran the worker against the BPM in `gs://cpg-common-main/references/illumina_microarray/` and the GRCh38 fasta. Counts (sum to `num_loci`):

```
total           1904599
unmapped           3352
par                5490
non_snv           38898
unknown_strand        0
missing_contig        0
ref_mismatch         46
written         1856813
```

Output contigs are `chr1..chr22, chrX, chrY, chrM` (no `chr0`, no `chrXY`), single-base intervals, REF base verified against the fasta.

## Invocation

```
analysis-runner \
    --dataset common \
    --access-level full \
    --description 'Generate GDA biallelic SNV BED from BPM manifest' \
    --output-dir references/illumina_microarray \
    illumina_microarray/run_generate_bed_from_illumina_bpm.py
```

## Test plan

- [ ] Merge, let CI declare the path in `references.toml`.
- [ ] Run the AR invocation above at `--access-level test` first; confirm the BED lands in `cpg-common-test`.
- [ ] Spot-check a few rows against the BPM CSV.
- [ ] Re-run at `--access-level full` to populate `cpg-common-main`.